### PR TITLE
Fix extra quoting in _Interrupt macro added for GNU toolchain.

### DIFF
--- a/build/rules.mk
+++ b/build/rules.mk
@@ -145,7 +145,7 @@ else
  AR = arc-elf32-ar
  AS = arc-elf32-as
  CFLAGS += $(addprefix -I, $(HEADER_DIRS))
- CFLAGS += -D_Interrupt=__attribute__((interrupt(\"ilink\")))
+ CFLAGS += -D_Interrupt=__attribute__((interrupt("ilink")))
  CFLAGS += -D_lr=__builtin_arc_lr
  CFLAGS += -D_sr=__builtin_arc_sr
  CFLAGS += -D_seti=__builtin_arc_seti


### PR DESCRIPTION
We handle it in one place (differently for Unis/Windows platforms),
so no need to do it in each macro any longer