### PR TITLE
Fix w_ptr increment in conv2d_hwc_nopad

### DIFF
--- a/lib/src/kernels/convolution/mli_krn_conv2d_hwc.h
+++ b/lib/src/kernels/convolution/mli_krn_conv2d_hwc.h
@@ -599,6 +599,7 @@ static __attribute__ ((always_inline)) void convolution2D_hwc_nopad(
             weights_add = weights_additive(w_ptr++, weights_add, &quant_params, 
                     kernel_width, kernel_height, krn_col_step, krn_row_step);
         }
+        w_ptr -= in_ch;
 
         for (int H_idx = row_begin; H_idx < row_end; H_idx++) {
 


### PR DESCRIPTION
Add missing compensation of w_ptr after incremention for weights_additive calculations