### PR TITLE
Fix redifinition border variables in avepool_hwc_krnpad and maxpool_hwc_pad

### DIFF
--- a/lib/src/kernels/pooling/mli_krn_avepool_hwc.h
+++ b/lib/src/kernels/pooling/mli_krn_avepool_hwc.h
@@ -173,10 +173,10 @@ static inline void __attribute__((always_inline)) avepool_hwc(
 
 template <typename io_T>
 static inline void __attribute__((always_inline)) avepool_hwc_krnpad(
-        const int row_beg,
-        const int row_end,
-        const int clmn_beg,
-        const int clmn_end,
+        int row_beg,
+        int row_end,
+        int clmn_beg,
+        int clmn_end,
         const MLI_PTR(io_T) __restrict in_ftrs,
         MLI_OUT_PTR(io_T) __restrict out_ftrs,
         const int channels,
@@ -195,10 +195,10 @@ static inline void __attribute__((always_inline)) avepool_hwc_krnpad(
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
 
-    const int row_beg = CEIL_DIV(padding_top, stride_height);
-    const int row_end = out_height - CEIL_DIV(padding_bot, stride_height);
-    const int clmn_beg = CEIL_DIV(padding_left, stride_width);
-    const int clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
+    row_beg = CEIL_DIV(padding_top, stride_height);
+    row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+    clmn_beg = CEIL_DIV(padding_left, stride_width);
+    clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
 
     if ((row_end - row_beg > 0) && (clmn_end - clmn_beg > 0)) {
         avepool_hwc_nopad(

--- a/lib/src/kernels/pooling/mli_krn_maxpool_hwc.h
+++ b/lib/src/kernels/pooling/mli_krn_maxpool_hwc.h
@@ -191,10 +191,10 @@ static inline void __attribute__((always_inline)) maxpool_hwc_pad(
 
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
-    int row_beg = CEIL_DIV(padding_top, stride_height);
-    int row_end = out_height - CEIL_DIV(padding_bot, stride_height);
-    int clmn_beg = CEIL_DIV(padding_left, stride_width);
-    int clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
+    row_beg = CEIL_DIV(padding_top, stride_height);
+    row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+    clmn_beg = CEIL_DIV(padding_left, stride_width);
+    clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
 
     if ((row_end - row_beg > 0) && (clmn_end - clmn_beg > 0)) {
         maxpool_hwc_nopad<io_T>(


### PR DESCRIPTION
Border variables are row_beg, row_end, clmn_beg, clmn_end.