### PR TITLE
[memory strides] add memory stride support to kernels

### DIFF
--- a/build/rules.mk
+++ b/build/rules.mk
@@ -119,6 +119,7 @@ else
 ifeq ($(TOOLCHAIN),mwdt)
 # place to add MWDT-specific common settings
 CFLAGS     +=-Hon=Long_enums
+CFLAGS     +=-mllvm -gen-lpcc=false
 DEPFLAGS    =-Hdepend=$(BUILD_DIR)/ -MD
 else
 $(error ERROR - Unsupported toolchain. Supported toolchains are 'gnu' and 'mwdt', default one is 'gnu')

--- a/include/mli_config.h
+++ b/include/mli_config.h
@@ -98,12 +98,18 @@
 */
 #if (ARC_PLATFORM == V2DSP_XY)
 #define MLI_PTR(p) __xy p *
+#define MLI_PTR_IS_XY true
 #define MLI_OUT_PTR(p) __xy p *
+#define MLI_OUT_PTR_IS_XY true
 #define MLI_CONV_OUT_PTR(p) p *
+#define MLI_CONV_OUT_PTR_IS_XY false
 #else
 #define MLI_PTR(p) p *
+#define MLI_PTR_IS_XY false
 #define MLI_OUT_PTR(p) p *
+#define MLI_OUT_PTR_IS_XY false
 #define MLI_CONV_OUT_PTR(p) p *
+#define MLI_CONV_OUT_PTR_IS_XY false
 #endif
 
 #endif // _MLI_CONFIG_H_

--- a/lib/gen/mli_krn_avepool_chw_func_body.txt
+++ b/lib/gen/mli_krn_avepool_chw_func_body.txt
@@ -9,9 +9,13 @@
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR($d_type), MLI_PTR_IS_XY>(in,
+            $channels); // channels
+
     // assign hard coded values for this variation to some variables
 #if $stride_w
     MLI_CHECK_AND_FIX(stride_width, $stride_w);
@@ -31,20 +35,19 @@
 #if $kernel_h
     MLI_CHECK_AND_FIX(kernel_height, $kernel_h);
 #endif
-#if $channels
-    MLI_CHECK_AND_FIX(channels_num, $channels);
-#endif
-
-    // Data pointers
-    MLI_PTR($d_type) in_ftrs = (MLI_PTR($d_type ))in->data;
-    MLI_OUT_PTR($d_type) out_ftrs = (MLI_OUT_PTR($d_type ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR($d_type), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -56,20 +59,10 @@
     $core_name(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }

--- a/lib/gen/mli_krn_avepool_hwc_func_body.txt
+++ b/lib/gen/mli_krn_avepool_hwc_func_body.txt
@@ -9,9 +9,13 @@
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR($d_type), MLI_PTR_IS_XY>(in,
+            $channels); // channels
+
     // assign hard coded values for this variation to some variables
 #if $stride_w
     MLI_CHECK_AND_FIX(stride_width, $stride_w);
@@ -31,20 +35,19 @@
 #if $kernel_h
     MLI_CHECK_AND_FIX(kernel_height, $kernel_h);
 #endif
-#if $channels
-    MLI_CHECK_AND_FIX(channels_num, $channels);
-#endif
-
-    // Data pointers
-    MLI_PTR($d_type) in_ftrs = (MLI_PTR($d_type ))in->data;
-    MLI_OUT_PTR($d_type) out_ftrs = (MLI_OUT_PTR($d_type ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.$el_params = in->el_params.$el_params;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR($d_type), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -56,20 +59,10 @@
     $core_name(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.$el_params = in->el_params.$el_params;
 
     return MLI_STATUS_OK;
 }

--- a/lib/gen/mli_krn_conv2d_nhwc_func_body.txt
+++ b/lib/gen/mli_krn_conv2d_nhwc_func_body.txt
@@ -11,10 +11,15 @@
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int kernel_height = weights->shape[KRNL_H_DIM_HWC];
-    int kernel_width = weights->shape[KRNL_W_DIM_HWC];
-    int out_ch = weights->shape[KRNL_C_DIM_HWC];
-    int in_ch = in->shape[FMAP_C_DIM_HWC];
+
+    // Define Data dimensions
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR($d_type), MLI_PTR_IS_XY>(in,
+            $channels); // channels
+    const auto w = mli_prv_get_conv2d_weights_tensor_nhwc<MLI_PTR($w_type), MLI_PTR_IS_XY>(weights,
+            $channels,  // channels
+            $kernel_w,  // kernel_width
+            $kernel_h); // kernel_height
+    __builtin_assume(in_prv.ch == w.in_ch);
 
     // assign hard coded values for this variation to some variables
 #if $stride_w
@@ -29,15 +34,6 @@
     MLI_CHECK_AND_FIX(padding_left, $padding_left);
     MLI_CHECK_AND_FIX(padding_right, $padding_right);
 #endif
-#if $kernel_w
-    MLI_CHECK_AND_FIX(kernel_width, $kernel_w);
-#endif
-#if $kernel_h
-    MLI_CHECK_AND_FIX(kernel_height, $kernel_h);
-#endif
-#if $channels
-    MLI_CHECK_AND_FIX(in_ch, $channels);
-#endif
 
     mli_minmax_t val_limit;
     // fill output tensor el_type parameter
@@ -46,17 +42,18 @@
     val_limit = mli_prv_get_relu_min_max(&cfg->relu, out);
 
     // Data pointers
-    MLI_PTR($d_type) in_ftrs = (MLI_PTR($d_type ))in->data;
-    MLI_CONV_OUT_PTR($d_type) out_ftrs = (MLI_CONV_OUT_PTR($d_type ))out->data;
-    MLI_PTR($w_type) wt = (MLI_PTR($w_type ))weights->data;
     MLI_PTR($b_type) bs = (MLI_PTR($b_type ))bias->data;
 
     // Define Data dimensions
-    int in_height = in->shape[FMAP_H_DIM_HWC];
-    int in_width = in->shape[FMAP_W_DIM_HWC];
+    int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-    int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_HWC] = w.out_ch;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR($d_type), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     // Define quantization specific params
     s8asym_quant_specific_params params;
@@ -70,16 +67,11 @@
     cent_area.clmn_end = out_width;
 
     $core_name<$d_type, $w_type, $b_type, int32_t>(
-            in_ftrs, wt, bs, out_ftrs, &cent_area, params,
-            (int8_t)val_limit.min, (int8_t)val_limit.max, in_ch, in_width, in_height, 
-            out_ch, out_width, out_height, kernel_height, kernel_width,
-            stride_height, stride_width, padding_top, padding_left, padding_bot, padding_right);
-
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_HWC] = out_ch;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
+        in_prv, w, bs, out_prv,
+        &cent_area, params,
+        (int8_t)val_limit.min, (int8_t)val_limit.max,
+        stride_height, stride_width,
+        padding_top, padding_left, padding_bot, padding_right);
 
     return MLI_STATUS_OK;
 }

--- a/lib/gen/mli_krn_depthwise_conv2d_hwcn_func_body.txt
+++ b/lib/gen/mli_krn_depthwise_conv2d_hwcn_func_body.txt
@@ -11,10 +11,14 @@
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int kernel_height = weights->shape[KRNL_DW_H_DIM_HWC];
-    int kernel_width = weights->shape[KRNL_DW_W_DIM_HWC];
-    int out_ch = weights->shape[KRNL_DW_C_DIM_HWC];
-    int in_ch = in->shape[FMAP_C_DIM_HWC];
+
+    // Define Data dimensions
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR($d_type), MLI_PTR_IS_XY>(in,
+            $channels); // channels
+    const auto w = mli_prv_get_conv2d_weights_tensor_1hwn<MLI_PTR($w_type), MLI_PTR_IS_XY>(
+            weights,
+            $kernel_w,  // kernel_width
+            $kernel_h); // kernel_height
 
     // assign hard coded values for this variation to some variables
 #if $stride_w
@@ -29,15 +33,6 @@
     MLI_CHECK_AND_FIX(padding_left, $padding_left);
     MLI_CHECK_AND_FIX(padding_right, $padding_right);
 #endif
-#if $kernel_w
-    MLI_CHECK_AND_FIX(kernel_width, $kernel_w);
-#endif
-#if $kernel_h
-    MLI_CHECK_AND_FIX(kernel_height, $kernel_h);
-#endif
-#if $channels
-    MLI_CHECK_AND_FIX(in_ch, $channels);
-#endif
 
     mli_minmax_t val_limit;
     // fill output tensor el_type parameter
@@ -46,18 +41,18 @@
     val_limit = mli_prv_get_relu_min_max(&cfg->relu, out);
 
     // Data pointers
-    MLI_PTR($d_type) in_ftrs = (MLI_PTR($d_type ))in->data;
-    MLI_CONV_OUT_PTR($d_type) out_ftrs = (MLI_CONV_OUT_PTR($d_type ))out->data;
-    MLI_PTR($w_type) wt = (MLI_PTR($w_type ))weights->data;
     MLI_PTR($b_type) bs = (MLI_PTR($b_type ))bias->data;
 
      // Define Data dimensions
-    int in_height = in->shape[FMAP_H_DIM_HWC];
-    int in_width = in->shape[FMAP_W_DIM_HWC];
+    int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-
-    int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_HWC] = w.out_ch;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR($d_type), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     // Define quantization specific params
     s8asym_quant_specific_params params;
@@ -71,16 +66,9 @@
     cent_area.clmn_end = out_width;
 
     $core_name<$d_type, $w_type, $b_type, int32_t>(
-            in_ftrs, wt, bs, out_ftrs, &cent_area, params,
-            (int8_t)val_limit.min, (int8_t)val_limit.max, in_ch, in_width, in_height, 
-            out_ch, out_width, out_height, kernel_height, kernel_width,
+            in_prv, w, bs, out_prv, &cent_area, params,
+            (int8_t)val_limit.min, (int8_t)val_limit.max,
             stride_height, stride_width, padding_top, padding_left, padding_bot, padding_right);
-
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_HWC] = out_ch;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
 
     return MLI_STATUS_OK;
 }

--- a/lib/gen/mli_krn_maxpool_chw_func_body.txt
+++ b/lib/gen/mli_krn_maxpool_chw_func_body.txt
@@ -9,9 +9,13 @@
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR($d_type), MLI_PTR_IS_XY>(in,
+            $channels); // channels
+
     // assign hard coded values for this variation to some variables
 #if $stride_w
     MLI_CHECK_AND_FIX(stride_width, $stride_w);
@@ -31,20 +35,19 @@
 #if $kernel_h
     MLI_CHECK_AND_FIX(kernel_height, $kernel_h);
 #endif
-#if $channels
-    MLI_CHECK_AND_FIX(channels_num, $channels);
-#endif
-
-    // Data pointers
-    MLI_PTR($d_type) in_ftrs = (MLI_PTR($d_type ))in->data;
-    MLI_OUT_PTR($d_type) out_ftrs = (MLI_OUT_PTR($d_type ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR($d_type), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -54,23 +57,13 @@
     mli_prv_fx_init_dsp_ctrl();
 
     $core_name(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         $kernelpadding);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }

--- a/lib/gen/mli_krn_maxpool_hwc_func_body.txt
+++ b/lib/gen/mli_krn_maxpool_hwc_func_body.txt
@@ -9,9 +9,13 @@
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR($d_type), MLI_PTR_IS_XY>(in,
+            $channels); // channels
+
     // assign hard coded values for this variation to some variables
 #if $stride_w
     MLI_CHECK_AND_FIX(stride_width, $stride_w);
@@ -31,20 +35,19 @@
 #if $kernel_h
     MLI_CHECK_AND_FIX(kernel_height, $kernel_h);
 #endif
-#if $channels
-    MLI_CHECK_AND_FIX(channels_num, $channels);
-#endif
-
-    // Data pointers
-    MLI_PTR($d_type) in_ftrs = (MLI_PTR($d_type ))in->data;
-    MLI_OUT_PTR($d_type) out_ftrs = (MLI_OUT_PTR($d_type ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.$el_params = in->el_params.$el_params;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR($d_type), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -57,17 +60,8 @@
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.$el_params = in->el_params.$el_params;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/helpers/src/mli_helpers.cc
+++ b/lib/src/helpers/src/mli_helpers.cc
@@ -18,6 +18,9 @@
 
 #pragma Code(".mli_lib")
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static void convert_tensor_fx8_to_fx8(
         const MLI_PTR(int8_t) __restrict in, 
@@ -247,5 +250,9 @@ mli_status mli_hlp_convert_tensor(mli_tensor *in, mli_tensor *out) {
     out->rank = in->rank;
     return MLI_STATUS_OK;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #pragma code()

--- a/lib/src/kernels/convolution/mli_krn_conv2d_hwc.h
+++ b/lib/src/kernels/convolution/mli_krn_conv2d_hwc.h
@@ -18,6 +18,7 @@
 #include "mli_krn_dotprod.h"
 #include "mli_krn_reduce_sum2d.h"
 #include "mli_math.h"
+#include "mli_private_types.h"
 #include "mli_prv_aux_calc.h"
 #include "mli_prv_dsp.h"
 #include "mli_prv_tensor.h"
@@ -29,19 +30,14 @@
 //========================================================
 template <typename io_T, typename w_T, typename b_T, typename acc_T>
 static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_nopad(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        const MLI_PTR(w_T)  __restrict weights,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(w_T)> &w,
         const MLI_PTR(b_T)  __restrict biases,
-              MLI_CONV_OUT_PTR(io_T) __restrict out_ftrs,
-
+        const tensor_private_t<MLI_CONV_OUT_PTR(io_T)> &out,
         const rect_t * const perception_area,
         s8asym_quant_specific_params quant_params,
         const io_T val_min_limit,
         const io_T val_max_limit,
-
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width, const int out_height,
-        const int kernel_height, const int kernel_width,
         const int stride_height, const int stride_width,
         const int padding_top, const int padding_left,
         const int padding_bot, const int padding_right) {
@@ -50,43 +46,34 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_nopad(
     const int clmn_begin = perception_area->clmn_beg;
     const int clmn_end = perception_area->clmn_end;
     const int filters = 1;
-    const int in_col_step = in_ch * filters;
-    const int in_row_step = in_width * in_ch * filters;
-    const int krn_col_step = out_ch; /*channels == 1 */
-    const int krn_row_step = kernel_width * out_ch; /*channels == 1 */
-    const int ch_mul = out_ch / in_ch;
-
+    const int ch_mul = out.ch / in.ch;
     const int amount_rows = row_end - row_begin;
     const int amount_columns = clmn_end - clmn_begin;
-    const int in_compensation_row_loop = in_ch * stride_height * in_width * filters * amount_rows;
-    const int out_compensation_row_loop = out_ch * out_width * filters * amount_rows;
-    const int in_compensation_clmn_loop = stride_width * filters * in_ch * amount_columns;
-    const int out_compensation_clmn_loop = filters * out_ch * amount_columns;
-    const int in_increment_clmn_loop = stride_width * filters * in_ch;
-    const int out_increment_clmn_loop = filters * out_ch;
-    const int in_increment_row_loop = in_ch * stride_height * in_width * filters - in_compensation_clmn_loop;
-    const int out_increment_row_loop = out_ch * out_width * filters  - out_compensation_clmn_loop;
+    const int in_compensation_row_loop   = in.row_mem_stride * stride_height * amount_rows;
+    const int out_compensation_row_loop  = out.row_mem_stride * amount_rows;
+    const int in_compensation_clmn_loop  = in.col_mem_stride * stride_width * amount_columns;
+    const int out_compensation_clmn_loop = out.col_mem_stride * amount_columns;
+    const int in_increment_clmn_loop     = in.col_mem_stride * stride_width;
+    const int in_increment_row_loop      = in.row_mem_stride * stride_height - in_compensation_clmn_loop;
+    const int out_increment_row_loop     = out.row_mem_stride  - out_compensation_clmn_loop;
     const int channel_per_loop = 1;
     const int channels_per_loop_v = 2;
     const int out_increment_in_ch_loop = channel_per_loop - out_compensation_row_loop;
     const int out_increment_in_ch_loop_v = channels_per_loop_v - out_compensation_row_loop;
 
-    const MLI_PTR(io_T) __restrict in_ptr = (MLI_PTR(io_T) __restrict)in_ftrs;
-    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = (MLI_CONV_OUT_PTR(io_T) __restrict)out_ftrs;
-    const MLI_PTR(w_T) __restrict w_ptr = (MLI_PTR(w_T) __restrict)weights;
-    // MLI_PTR(w_T) __restrict w_ptr_local = (MLI_PTR(w_T) __restrict)weights;
+    const MLI_PTR(w_T) __restrict w_ptr = w.ptr;
     int out_ch_idx = 0;
 
-    in_ptr += in_ch * filters *                     // common coefs
-        ((row_begin * stride_height - padding_top) * in_width  +    // setup init coef for moving to row
-        (clmn_begin * stride_width - padding_left)) ;                // setup init coef for moving to colum;
-    
-    out_ptr += out_ch * filters *       // common coefs
-            (row_begin * out_width  +   // setup init coef for moving to row
-            clmn_begin) ;               // setup init coef for moving to colum;
+    const MLI_PTR(io_T) __restrict in_ptr = in.ptr
+            + in.col_mem_stride * (clmn_begin * stride_width - padding_left) // move to column
+            + in.row_mem_stride * (row_begin * stride_height - padding_top); // move to row
+
+    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = out.ptr
+            + out.col_mem_stride * clmn_begin // move to column
+            + out.row_mem_stride * row_begin; // move to row
 
     s8asym_quant_specific_params v2quant_params[] = {quant_params, quant_params};
-    for (int in_ch_idx = 0; in_ch_idx < in_ch-1; in_ch_idx += 2) {
+    for (int in_ch_idx = 0; in_ch_idx < in.ch-1; in_ch_idx += 2) {
         for (int ch_mult_idx = 0; ch_mult_idx < ch_mul; ch_mult_idx++) {
             adjust_quant_params(&v2quant_params[0], out_ch_idx++);
             adjust_quant_params(&v2quant_params[1], out_ch_idx++);
@@ -95,24 +82,24 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_nopad(
             acc_T bias_add_ch2 = bias_additive(*biases++, 0x0, &v2quant_params[1]);
 
             __v2i32_t v2acc_weights_add = {bias_add_ch1, bias_add_ch2};
-            v2acc_weights_add = weights_additive_v(w_ptr, &v2acc_weights_add, &quant_params, kernel_width, kernel_height, 
-                    krn_col_step, krn_row_step);
+            v2acc_weights_add = weights_additive_v(w_ptr, &v2acc_weights_add, &quant_params, w.kernel_width, w.kernel_height,
+                    w.col_mem_stride, w.row_mem_stride);
             __builtin_assume(amount_rows > 0);
             for (int H_idx = 0; H_idx < amount_rows; H_idx++) {
                 __builtin_assume(amount_columns > 0);
 
                 __v2i32_t v2accu_dotprod = v2acc_weights_add;
                 for (int W_idx = 0; W_idx < amount_columns; W_idx++) {
-                    dotprod2D_hwc_v(&in_ptr, &w_ptr, &v2accu_dotprod, kernel_width, kernel_height,
-                                    in_col_step, in_row_step, krn_col_step, krn_row_step);
+                    dotprod2D_hwc_v(&in_ptr, &w_ptr, &v2accu_dotprod, w.kernel_width, w.kernel_height,
+                                    in.col_mem_stride, in.row_mem_stride, w.col_mem_stride, w.row_mem_stride);
                     //compensite increment of input tensor pointer from dotprod2D_hwc_v function
-                    in_ptr += in_increment_clmn_loop - kernel_height * in_row_step;
+                    in_ptr += in_increment_clmn_loop - w.kernel_height * in.row_mem_stride;
                     //compensite increment of weights pointer from dotprod2D_hwc_v function
-                    w_ptr -= kernel_height * krn_row_step;
+                    w_ptr -= w.kernel_height * w.row_mem_stride;
 
                     // Cast result to output type
                     mli_prv_clip_relu_store_output_v(out_ptr, &v2accu_dotprod, v2quant_params, val_min_limit, val_max_limit);
-                    out_ptr += out_increment_clmn_loop;
+                    out_ptr += out.col_mem_stride;
 
                     v2accu_dotprod = v2acc_weights_add;
                 } // for W_idx
@@ -128,12 +115,12 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_nopad(
         in_ptr += 2 * filters;
     } // for in_ch_idx
 
-    if(in_ch & 1){
+    if (in.ch & 1) {
         for (int ch_mult_idx = 0; ch_mult_idx < ch_mul; ch_mult_idx++) {
             adjust_quant_params(&quant_params, out_ch_idx);
 
-            acc_T global_other_additives = weights_additive(w_ptr, 0x0, &quant_params, kernel_width, kernel_height, 
-                    krn_col_step, krn_row_step);
+            acc_T global_other_additives = weights_additive(w_ptr, 0x0, &quant_params, w.kernel_width, w.kernel_height,
+                    w.col_mem_stride, w.row_mem_stride);
             global_other_additives += bias_additive(*biases, 0x0, &quant_params);
             __v2i32_t v2global_other_additives = {global_other_additives, global_other_additives};
 
@@ -143,32 +130,32 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_nopad(
                     // out_val = (x-x_zp)*(w) + b) = -sum_i(w*x_zp) + sum(x*w) + b
                     //============================================
                     __v2i32_t accu = v2global_other_additives;
-                    accu = dotprod2D_inp_width_v(&in_ptr, &w_ptr, &accu, kernel_width, kernel_height,
-                                        in_col_step, in_row_step, krn_col_step, krn_row_step, in_increment_clmn_loop);
+                    accu = dotprod2D_inp_width_v(&in_ptr, &w_ptr, &accu, w.kernel_width, w.kernel_height,
+                            in.col_mem_stride, in.row_mem_stride, w.col_mem_stride, w.row_mem_stride, in_increment_clmn_loop);
                     //compensite increment of input tensor pointer from dotprod2D_hwc_v function
-                    in_ptr += 2 * in_increment_clmn_loop - kernel_height * in_row_step;
+                    in_ptr += 2 * in_increment_clmn_loop - w.kernel_height * in.row_mem_stride;
                     //compensite increment of weights pointer from dotprod2D_hwc_v function
-                    w_ptr -= kernel_height * krn_row_step;
+                    w_ptr -= w.kernel_height * w.row_mem_stride;
                     // Cast result to output type
-                    mli_prv_clip_relu_store_output_inp_width_v(out_ptr, &accu, &quant_params, val_min_limit, val_max_limit, out_increment_clmn_loop);
-                    out_ptr += 2 * out_increment_clmn_loop;
+                    mli_prv_clip_relu_store_output_inp_width_v(out_ptr, &accu, &quant_params, val_min_limit, val_max_limit, out.col_mem_stride);
+                    out_ptr += 2 * out.col_mem_stride;
                 } // for W_idx
-                if( amount_columns & 0x1) {
+                if (amount_columns & 0x1) {
                     // Convolution core. Here calculations performes in a unfolded expression way: 
                     // out_val = (x-x_zp)*(w) + b) = -sum_i(w*x_zp) + sum(x*w) + b
                     //============================================
                     acc_T accu = 0;
-                    accu = dotprod2D(&in_ptr, &w_ptr, accu, kernel_width, kernel_height,
-                                        in_col_step, in_row_step, krn_col_step, krn_row_step);
+                    accu = dotprod2D(&in_ptr, &w_ptr, accu, w.kernel_width, w.kernel_height,
+                            in.col_mem_stride, in.row_mem_stride, w.col_mem_stride, w.row_mem_stride);
                     //compensite increment of input tensor pointer from dotprod2D_hwc_v function
-                    in_ptr += in_increment_clmn_loop - kernel_height * in_row_step;
+                    in_ptr += in_increment_clmn_loop - w.kernel_height * in.row_mem_stride;
                     //compensite increment of weights pointer from dotprod2D_hwc_v function
-                    w_ptr -= kernel_height * krn_row_step;
+                    w_ptr -= w.kernel_height * w.row_mem_stride;
                     accu += global_other_additives;
 
                     // Cast result to output type
                     mli_prv_clip_relu_store_output(out_ptr, accu, &quant_params, val_min_limit, val_max_limit);
-                    out_ptr += out_increment_clmn_loop;
+                    out_ptr += out.col_mem_stride;
                 }
                 in_ptr += in_increment_row_loop;
                 out_ptr += out_increment_row_loop;
@@ -185,19 +172,14 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_nopad(
 
 template <typename io_T, typename w_T, typename b_T, typename acc_T>
 static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        const MLI_PTR(w_T)  __restrict weights,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(w_T)> &w,
         const MLI_PTR(b_T)  __restrict biases,
-              MLI_CONV_OUT_PTR(io_T) __restrict out_ftrs,
-
+        const tensor_private_t<MLI_CONV_OUT_PTR(io_T)> &out,
         const rect_t * const perception_area,
         s8asym_quant_specific_params quant_params,
         const io_T val_min_limit,
         const io_T val_max_limit,
-
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width, const int out_height,
-        const int kernel_height, const int kernel_width,
         const int stride_height, const int stride_width,
         const int padding_top, const int padding_left,
         const int padding_bot, const int padding_right) {
@@ -206,32 +188,24 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn(
     const int row_end = perception_area->row_end;
     const int clmn_begin = perception_area->clmn_beg;
     const int clmn_end = perception_area->clmn_end;
-    const int in_col_step = mli_prv_column_step<LAYOUT_HWCN>(in_height, in_width, in_ch, /*filters =*/ 1);
-    const int in_row_step = mli_prv_row_step<LAYOUT_HWCN>(in_height, in_width, in_ch, /*filters =*/ 1);
-    const int krn_col_step = mli_prv_column_step<LAYOUT_HWCN>(kernel_height, kernel_width, /*channels =*/ 1, out_ch);
-    const int krn_row_step = mli_prv_row_step<LAYOUT_HWCN>(kernel_height, kernel_width, /*channels =*/ 1, out_ch);
-    const int ch_mul = out_ch / in_ch;
-    const int filters = 1;
-
+    const int ch_mul = out.ch / in.ch;
     const int amount_rows = row_end - row_begin;
     const int amount_columns = clmn_end - clmn_begin;
-    const int out_compensation_row_loop = out_ch * out_width * filters * amount_rows;
-    const int out_compensation_clmn_loop = filters * out_ch * amount_columns;
-    const int out_increment_clmn_loop = filters * out_ch;
-    const int out_increment_row_loop = out_ch * out_width * filters  - out_compensation_clmn_loop;
+    const int out_compensation_row_loop  = out.row_mem_stride * amount_rows;
+    const int out_compensation_clmn_loop = out.col_mem_stride * amount_columns;
+    const int out_increment_row_loop     = out.row_mem_stride  - out_compensation_clmn_loop;
     const int channel_per_loop = 1;
     const int channels_per_loop_v = 2;
     const int out_increment_in_ch_loop = channel_per_loop - out_compensation_row_loop;
     const int out_increment_in_ch_loop_v = channels_per_loop_v - out_compensation_row_loop;
     int out_ch_idx = 0;
 
-    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = (MLI_CONV_OUT_PTR(io_T) __restrict)out_ftrs;
-    out_ptr += out_ch * filters *       // common coefs
-            (row_begin * out_width  +   // setup init coef for moving to row
-            clmn_begin) ;               // setup init coef for moving to colum;
+    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = out.ptr
+            + out.col_mem_stride * clmn_begin // move to columm
+            + out.row_mem_stride * row_begin; // move to row
 
     s8asym_quant_specific_params v2quant_params[] = {quant_params, quant_params};
-    for (int in_ch_idx = 0; in_ch_idx < in_ch - 1; in_ch_idx += 2) {
+    for (int in_ch_idx = 0; in_ch_idx < in.ch - 1; in_ch_idx += 2) {
         for (int ch_mult_idx = 0; ch_mult_idx < ch_mul; ch_mult_idx++) {
             adjust_quant_params(&v2quant_params[0], out_ch_idx);
             adjust_quant_params(&v2quant_params[1], out_ch_idx + 1);
@@ -245,53 +219,54 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn(
                 // comp - compensation values for valid area definition
                 mli_compensations comp;
                 comp.top    = -MIN((H_idx * stride_height)- padding_top, 0);
-                comp.bottom = -MIN(in_height - ((H_idx * stride_height)- padding_top + kernel_height), 0);
-                const int rows = kernel_height - comp.top - comp.bottom;
+                comp.bottom = -MIN(in.height - ((H_idx * stride_height)- padding_top + w.kernel_height), 0);
+                const int rows = w.kernel_height - comp.top - comp.bottom;
                 const int h_idx_in = (H_idx * stride_height - padding_top + comp.top);
-                MLI_PTR(io_T) __restrict in_ptr = (MLI_PTR(io_T) __restrict)in_ftrs 
-                        + h_idx_in * in_width * in_ch * filters                 // move to row
-                        // + w_idx * in_ch * filters                            // move to column
-                        + in_ch_idx * filters;                                  // move to channel
-                MLI_PTR(w_T) __restrict w_ptr = (MLI_PTR(w_T) __restrict)weights
-                        + comp.top * kernel_width * filters * out_ch            // move to row
-                        //+ comp.left * filters * out_ch                        // move to column
-                        + out_ch_idx;                                           // move to filter
+                MLI_PTR(io_T) __restrict in_ptr = in.ptr
+                        + in.row_mem_stride * h_idx_in // move to row
+                        + in_ch_idx;                   // move to channel
+                MLI_PTR(w_T) __restrict w_ptr = w.ptr
+                        + w.row_mem_stride * comp.top // move to row
+                        + out_ch_idx;                 // move to filter
 
                 for (int W_idx = clmn_begin; W_idx < clmn_end; W_idx++) {
                     // Define area of input and filter for convolution
                     // comp - compensation values for valid area definition
                     comp.left   = -MIN((W_idx * stride_width)- padding_left, 0);
-                    comp.right  = -MIN(in_width - ((W_idx * stride_width)- padding_left + kernel_width), 0);
-                    const int clmns = kernel_width - comp.right - comp.left;
+                    comp.right  = -MIN(in.width - ((W_idx * stride_width)- padding_left + w.kernel_width), 0);
+                    const int clmns = w.kernel_width - comp.right - comp.left;
                     const int w_idx_in = (W_idx * stride_width - padding_left + comp.left);
 
                     // Convolution core. Here calculations performes in a unfolded expression way: 
                     // out_val = (x-x_zp)*(w) + b) = -sum_i(w*x_zp) + sum(x*w) + b
                     //============================================
                     __v2i32_t v2accu_dotprod = {0, 0};
-                    dotprod2D_hwc_v(&in_ptr[w_idx_in * in_ch * filters], &w_ptr[comp.left * filters * out_ch], &v2accu_dotprod, clmns, rows,
-                                        in_col_step, in_row_step, krn_col_step, krn_row_step);
+                    dotprod2D_hwc_v(
+                            &in_ptr[in.col_mem_stride * w_idx_in],
+                            &w_ptr[w.col_mem_stride * comp.left], &v2accu_dotprod, clmns, rows,
+                            in.col_mem_stride, in.row_mem_stride, w.col_mem_stride, w.row_mem_stride);
 
                     __v2i32_t v2acc_weights_add = {0, 0};
-                    v2acc_weights_add = weights_additive_v(&w_ptr[comp.left * filters * out_ch], &v2acc_weights_add, &quant_params, clmns, rows, krn_col_step, krn_row_step);
+                    v2acc_weights_add = weights_additive_v(
+                            &w_ptr[w.col_mem_stride * comp.left], &v2acc_weights_add, &quant_params, clmns, rows,
+                            w.col_mem_stride, w.row_mem_stride);
 
                     v2accu_dotprod += v2acc_weights_add;
                     v2accu_dotprod += v2_bias_add;
 
                     // Cast result to output type
-
                     mli_prv_clip_relu_store_output_v(out_ptr, &v2accu_dotprod, v2quant_params, val_min_limit, val_max_limit);
 
-                    out_ptr += filters * out_ch;
+                    out_ptr += out.col_mem_stride;
                 } // for W_idx
-                out_ptr += out_ch * out_width * filters - out_compensation_clmn_loop;
+                out_ptr += out.row_mem_stride - out_compensation_clmn_loop;
             } // for H_idx
             out_ptr += out_increment_in_ch_loop_v;
             out_ch_idx += 2;
         } // for ch_mult_idx
     } // for in_ch_idx
 
-    if (in_ch & 1) {
+    if (in.ch & 1) {
         for (int ch_mult_idx = 0; ch_mult_idx < ch_mul; ch_mult_idx++) {
 
             adjust_quant_params(&quant_params, out_ch_idx);
@@ -302,34 +277,36 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn(
                 // comp - compensation values for valid area definition
                 mli_compensations comp;
                 comp.top    = -MIN((H_idx * stride_height)- padding_top, 0);
-                comp.bottom = -MIN(in_height - ((H_idx * stride_height)- padding_top + kernel_height), 0);
-                const int rows = kernel_height - comp.top - comp.bottom;
+                comp.bottom = -MIN(in.height - ((H_idx * stride_height)- padding_top + w.kernel_height), 0);
+                const int rows = w.kernel_height - comp.top - comp.bottom;
                 const int h_idx_in = (H_idx * stride_height - padding_top + comp.top);
-                MLI_PTR(io_T) __restrict in_ptr = (MLI_PTR(io_T) __restrict)in_ftrs 
-                        + h_idx_in * in_width * in_ch * filters                 // move to row
-                        // + w_idx * in_ch * filters                            // move to column
-                        + (in_ch - 1) * filters;                                  // move to channel
-                MLI_PTR(w_T) __restrict w_ptr = (MLI_PTR(w_T) __restrict)weights
-                        + comp.top * kernel_width * filters * out_ch            // move to row
-                        //+ comp.left * filters * out_ch                        // move to column
-                        + out_ch_idx;                                           // move to filter
+                MLI_PTR(io_T) __restrict in_ptr = in.ptr
+                        + in.row_mem_stride * h_idx_in // move to row
+                        + in.ch - 1;                   // move to channel
+                MLI_PTR(w_T) __restrict w_ptr = w.ptr
+                        + w.row_mem_stride * comp.top // move to row
+                        + out_ch_idx;                 // move to filter
 
                 for (int W_idx = clmn_begin; W_idx < clmn_end; W_idx++) {
                     // Define area of input and filter for convolution
                     // comp - compensation values for valid area definition
-                    comp.left   = -MIN((W_idx * stride_width)- padding_left, 0);
-                    comp.right  = -MIN(in_width - ((W_idx * stride_width)- padding_left + kernel_width), 0);
-                    const int clmns = kernel_width - comp.right - comp.left;
+                    comp.left  = -MIN((W_idx * stride_width) - padding_left, 0);
+                    comp.right = -MIN(in.width - ((W_idx * stride_width) - padding_left + w.kernel_width), 0);
+                    const int clmns = w.kernel_width - comp.right - comp.left;
                     const int w_idx_in = (W_idx * stride_width - padding_left + comp.left);
 
                     // Convolution core. Here calculations performes in a unfolded expression way: 
                     // out_val = (x-x_zp)*(w) + b) = -sum_i(w*x_zp) + sum(x*w) + b
                     //============================================
                     acc_T accu = mli_math_mul_fx<io_T, acc_T>(0, 0);
-                    accu = dotprod2D(&in_ptr[w_idx_in * in_ch * filters], &w_ptr[comp.left * filters * out_ch], accu, clmns, rows,
-                                        in_col_step, in_row_step, krn_col_step, krn_row_step);
+                    accu = dotprod2D(
+                            &in_ptr[in.col_mem_stride * w_idx_in],
+                            &w_ptr[w.col_mem_stride * comp.left], accu, clmns, rows,
+                            in.col_mem_stride, in.row_mem_stride, w.col_mem_stride, w.row_mem_stride);
 
-                    int32_t w_adds = weights_additive(&w_ptr[comp.left * filters * out_ch], 0x0, &quant_params, clmns, rows, krn_col_step, krn_row_step);
+                    int32_t w_adds = weights_additive(
+                            &w_ptr[w.col_mem_stride * comp.left], 0x0, &quant_params, clmns, rows,
+                            w.col_mem_stride, w.row_mem_stride);
 
                     accu += w_adds;
                     accu += bias_add;
@@ -337,7 +314,7 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn(
                     // Cast result to output type
                     mli_prv_clip_relu_store_output(out_ptr, accu, &quant_params, val_min_limit, val_max_limit);
 
-                    out_ptr += out_increment_clmn_loop;
+                    out_ptr += out.col_mem_stride;
                 } // for W_idx
                 out_ptr += out_increment_row_loop;
             } // for H_idx
@@ -349,19 +326,14 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn(
 
 template <typename io_T, typename w_T, typename b_T, typename acc_T>
 static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_krnpad(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        const MLI_PTR(w_T)  __restrict weights,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(w_T)> &w,
         const MLI_PTR(b_T)  __restrict biases,
-              MLI_CONV_OUT_PTR(io_T) __restrict out_ftrs,
-
+        const tensor_private_t<MLI_CONV_OUT_PTR(io_T)> &out,
         const rect_t * const perception_area,
         s8asym_quant_specific_params quant_params,
         const io_T val_min_limit,
         const io_T val_max_limit,
-
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width, const int out_height,
-        const int kernel_height, const int kernel_width,
         const int stride_height, const int stride_width,
         const int padding_top, const int padding_left,
         const int padding_bot, const int padding_right) {
@@ -370,18 +342,15 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_krnpad(
     //=======================================================================
     rect_t perception_area_nopad;
     perception_area_nopad.row_beg = CEIL_DIV(padding_top, stride_height);
-    perception_area_nopad.row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+    perception_area_nopad.row_end = out.height - CEIL_DIV(padding_bot, stride_height);
     perception_area_nopad.clmn_beg = CEIL_DIV(padding_left, stride_width);
-    perception_area_nopad.clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
+    perception_area_nopad.clmn_end = out.width - CEIL_DIV(padding_right, stride_width);
     
     if ((perception_area_nopad.row_end - perception_area_nopad.row_beg > 0)
         && (perception_area_nopad.clmn_end - perception_area_nopad.clmn_beg > 0)){
     depthwise_convolution2D_hwcn_nopad<int8_t, int8_t, int32_t, mli_acc32_t>(
-                in_ftrs, weights, biases, out_ftrs, &perception_area_nopad, quant_params,
-                    val_min_limit, val_max_limit,
-                in_ch, in_width, in_height,
-                out_ch, out_width, out_height,
-                kernel_height, kernel_width,
+                in, w, biases, out, &perception_area_nopad, quant_params,
+                val_min_limit, val_max_limit,
                 stride_height, stride_width,
                 padding_top, padding_left,
                 padding_bot, padding_right);
@@ -396,33 +365,30 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_krnpad(
             perc_areas[areas_num].row_beg = 0;
             perc_areas[areas_num].row_end = CEIL_DIV(padding_top, stride_height);
             perc_areas[areas_num].clmn_beg = 0;
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num++].clmn_end = out.width;
         }
         if (padding_bot) {
-            perc_areas[areas_num].row_beg = out_height - CEIL_DIV(padding_bot, stride_height);
-            perc_areas[areas_num].row_end = out_height;
+            perc_areas[areas_num].row_beg = out.height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].row_end = out.height;
             perc_areas[areas_num].clmn_beg = 0;
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num++].clmn_end = out.width;
         }
         if (padding_left) {
             perc_areas[areas_num].row_beg = CEIL_DIV(padding_top, stride_height);
-            perc_areas[areas_num].row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].row_end = out.height - CEIL_DIV(padding_bot, stride_height);
             perc_areas[areas_num].clmn_beg = 0;
             perc_areas[areas_num++].clmn_end = CEIL_DIV(padding_left, stride_width);
         }
         if (padding_right) {
             perc_areas[areas_num].row_beg = CEIL_DIV(padding_top, stride_height);
-            perc_areas[areas_num].row_end = out_height - CEIL_DIV(padding_bot, stride_height);
-            perc_areas[areas_num].clmn_beg = out_width - CEIL_DIV(padding_right, stride_width);
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num].row_end = out.height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].clmn_beg = out.width - CEIL_DIV(padding_right, stride_width);
+            perc_areas[areas_num++].clmn_end = out.width;
         }
         for(int i = 0; i < areas_num; i ++) {
             depthwise_convolution2D_hwcn<int8_t, int8_t, int32_t, mli_acc32_t>(
-                    in_ftrs, weights, biases, out_ftrs, &perc_areas[i], quant_params,
+                    in, w, biases, out, &perc_areas[i], quant_params,
                     val_min_limit, val_max_limit,
-                    in_ch, in_width, in_height,
-                    out_ch, out_width, out_height,
-                    kernel_height, kernel_width,
                     stride_height, stride_width,
                     padding_top, padding_left,
                     padding_bot, padding_right);
@@ -435,19 +401,14 @@ static __attribute__ ((always_inline)) void depthwise_convolution2D_hwcn_krnpad(
 //========================================================
 template <typename io_T, typename w_T, typename b_T, typename acc_T>
 static __attribute__ ((always_inline)) void convolution2D_nhwc(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        const MLI_PTR(w_T)  __restrict weights,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(w_T)> &w,
         const MLI_PTR(b_T)  __restrict biases,
-              MLI_CONV_OUT_PTR(io_T) __restrict out_ftrs,
-
+        const tensor_private_t<MLI_CONV_OUT_PTR(io_T)> &out,
         const rect_t * const perception_area,
         s8asym_quant_specific_params quant_params,
         const io_T val_min_limit,
         const io_T val_max_limit,
-
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width, const int out_height,
-        const int kernel_height, const int kernel_width,
         const int stride_height, const int stride_width,
         const int padding_top, const int padding_left,
         const int padding_bot, const int padding_right) {
@@ -456,41 +417,24 @@ static __attribute__ ((always_inline)) void convolution2D_nhwc(
     const int row_end = perception_area->row_end;
     const int clmn_begin = perception_area->clmn_beg;
     const int clmn_end = perception_area->clmn_end;
-    const int in_col_step = in_ch;
-    const int in_row_step = in_width * in_ch;
-    const int krn_col_step = in_ch;
-    const int krn_row_step = kernel_width * in_ch;
     const int amount_rows = row_end - row_begin;
     const int amount_columns = clmn_end - clmn_begin;
-    const int out_compensation_row_loop = out_ch * out_width * amount_rows;
-    const int out_compensation_clmn_loop = out_ch * amount_columns;
+    const int out_compensation_row_loop  = out.row_mem_stride * amount_rows;
+    const int out_compensation_clmn_loop = out.col_mem_stride * amount_columns;
 
-    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = (MLI_CONV_OUT_PTR(io_T) __restrict)out_ftrs;
-    out_ptr += out_ch *                 // common coefs
-            (row_begin * out_width  +   // setup init coef for moving to row
-            clmn_begin);                // setup init coef for moving to colum;
+    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = out.ptr
+            + out.row_mem_stride * row_begin   // setup init coef for moving to row
+            + out.col_mem_stride * clmn_begin; // setup init coef for moving to colum
 
-    for (int out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
-
+    for (int out_ch_idx = 0; out_ch_idx < out.ch; out_ch_idx++) {
         adjust_quant_params(&quant_params, out_ch_idx);
         const int bias_add = bias_additive(biases[out_ch_idx], 0x0, &quant_params);
 
         for (int H_idx = row_begin; H_idx < row_end; H_idx++) {
-
             mli_compensations comp;
-            comp.top    = -MIN((H_idx * stride_height)- padding_top, 0);
-            comp.bottom = -MIN(in_height - ((H_idx * stride_height)- padding_top + kernel_height), 0);
-            const int rows = kernel_height - comp.top - comp.bottom;
-            const int h_idx_in = (H_idx * stride_height - padding_top + comp.top);
-            MLI_PTR(io_T) __restrict in_ptr = (MLI_PTR(io_T) __restrict)in_ftrs 
-                    + h_idx_in * in_width * in_ch;   // move to row
-                    // + w_idx_in * in_ch              // move to column
-                    // + in_ch_idx;                    // move to channel
-            MLI_PTR(w_T) __restrict w_ptr = (MLI_PTR(w_T) __restrict)weights
-                    + out_ch_idx * kernel_height * kernel_width * in_ch     // move to filter
-                    + comp.top * kernel_width * in_ch;                      // move to row
-                    //+   comp.left * in_ch +                               // move to column
-                    //+   in_ch_idx;                                        // move to channel
+            comp.top    = -MIN((H_idx * stride_height) - padding_top, 0);
+            comp.bottom = -MIN(in.height - ((H_idx * stride_height) - padding_top + w.kernel_height), 0);
+            const int rows = w.kernel_height - comp.top - comp.bottom;
 
             int32_t w_adds = 0;
 
@@ -498,45 +442,63 @@ static __attribute__ ((always_inline)) void convolution2D_nhwc(
                 // Define area of input and filter for convolution
                 // comp - compensation values for valid area definition
                 comp.left   = -MIN((W_idx * stride_width)- padding_left, 0);
-                comp.right  = -MIN(in_width - ((W_idx * stride_width)- padding_left + kernel_width), 0);
+                comp.right  = -MIN(in.width - ((W_idx * stride_width)- padding_left + w.kernel_width), 0);
+                const int clmns = w.kernel_width - comp.right - comp.left;
 
-                const int clmns = kernel_width - comp.right - comp.left;
-                const int w_idx_in = (W_idx * stride_width - padding_left + comp.left);
+                const MLI_PTR (int8_t) in_ptr = in.ptr                                           // starting point
+                        + in.row_mem_stride * (H_idx * stride_height - padding_top + comp.top)   // move to row
+                        + in.col_mem_stride * (W_idx * stride_width - padding_left + comp.left); // move to column
+
+                const MLI_PTR (int8_t) w_ptr = w.ptr        // Start point
+                        + w.out_ch_mem_stride * out_ch_idx  // move to filter
+                        + w.row_mem_stride * comp.top       // move to row
+                        + w.col_mem_stride * comp.left;     // move to column
 
                 int8_t init_accum_weights_add_val = 0;
                 w_adds = mli_prv_init_accu(init_accum_weights_add_val);
 LOOP_PIPELINE_ENABLE
-                for (int in_ch_idx = 0; in_ch_idx < in_ch-1; in_ch_idx+=2) {
-                    w_adds = weights_additive_d(&w_ptr[comp.left * in_ch + in_ch_idx], &w_adds, &quant_params, 
-                                clmns, rows, krn_col_step, krn_row_step);
+                for (int in_ch_idx = 0; in_ch_idx < in.ch - 1; in_ch_idx += 2) {
+                    w_adds = weights_additive_d(
+                            &w_ptr[w.col_mem_stride * comp.left + in_ch_idx], &w_adds, &quant_params,
+                            clmns, rows, w.col_mem_stride, w.row_mem_stride);
                 }
-                if (in_ch & 1)
-                {
-                    w_adds = weights_additive(&w_ptr[comp.left * in_ch + in_ch-1], w_adds, &quant_params, 
-                            clmns, rows, krn_col_step, krn_row_step);
+                if (in.ch & 1) {
+                    w_adds = weights_additive(
+                            &w_ptr[w.col_mem_stride * comp.left + in.ch - 1], w_adds, &quant_params,
+                            clmns, rows, w.col_mem_stride, w.row_mem_stride);
                 }
 
                 int32_t init_accum_val = w_adds;
                 acc_T accu = mli_prv_init_accu(init_accum_val);
+
+                // Convolution core
 LOOP_PIPELINE_ENABLE
-                for (int in_ch_idx = 0; in_ch_idx < in_ch - 1; in_ch_idx+=2) {
-                    dotprod2D_hwc_d<io_T, w_T, acc_T>(&in_ptr[w_idx_in * in_ch + in_ch_idx], 
-                            &w_ptr[comp.left * in_ch + in_ch_idx], &accu, clmns, rows, in_col_step, in_row_step, 
-                            krn_col_step, krn_row_step);
+                for (int in_ch_idx = 0; in_ch_idx < in.ch - 1; in_ch_idx += 2) {
+                    dotprod2D_hwc_d(in_ptr, w_ptr, &accu, clmns, rows,
+                            in.col_mem_stride, in.row_mem_stride,
+                            w.col_mem_stride, w.row_mem_stride);
+                    in_ptr += 2;
+                    w_ptr += 2;
                 }
 
-                if (in_ch & 1)
-                {
-                    accu = dotprod2D(&in_ptr[w_idx_in * in_ch + in_ch - 1], &w_ptr[comp.left * in_ch + in_ch - 1], 
-                            accu, clmns, rows, in_col_step, in_row_step, krn_col_step, krn_row_step);
+                if (in.ch & 1) {
+                    accu = dotprod2D(in_ptr, w_ptr, accu, clmns, rows,
+                            in.col_mem_stride, in.row_mem_stride,
+                            w.col_mem_stride, w.row_mem_stride);
+                    in_ptr += 1;
+                    w_ptr += 1;
                 }
+
+                in_ptr -= in.ch;
+                w_ptr -= in.ch;
+
                 accu += bias_add;
 
                 // Cast result to output type, apply built-in ReLU Applying and write result
                 mli_prv_clip_relu_store_output(out_ptr, accu, &quant_params, val_min_limit, val_max_limit);
-                out_ptr += out_ch;
+                out_ptr += out.col_mem_stride;
             } // for W_idx
-            out_ptr += out_width * out_ch - out_compensation_clmn_loop;
+            out_ptr += out.row_mem_stride - out_compensation_clmn_loop;
         } // for H_idx
         out_ptr += 1 - out_compensation_row_loop;
     } // for out_ch_idx
@@ -544,66 +506,57 @@ LOOP_PIPELINE_ENABLE
 
 template <typename io_T, typename w_T, typename b_T, typename acc_T>
 static __attribute__ ((always_inline)) void convolution2D_nhwc_nopad(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        const MLI_PTR(w_T)  __restrict weights,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(w_T)> &w,
         const MLI_PTR(b_T)  __restrict biases,
-              MLI_CONV_OUT_PTR(io_T) __restrict out_ftrs,
-
+        const tensor_private_t<MLI_CONV_OUT_PTR(io_T)> &out,
         const rect_t * const perception_area,
         s8asym_quant_specific_params quant_params,
         const io_T val_min_limit,
         const io_T val_max_limit,
-
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width, const int out_height,
-        const int kernel_height, const int kernel_width,
         const int stride_height, const int stride_width,
         const int padding_top, const int padding_left,
         const int padding_bot, const int padding_right) {
-
     const int row_begin = perception_area->row_beg;
     const int row_end = perception_area->row_end;
     const int clmn_begin = perception_area->clmn_beg;
     const int clmn_end = perception_area->clmn_end;
-    const int in_col_step = in_ch;
-    const int in_row_step = in_width * in_ch;
-    const int krn_col_step = in_ch;
-    const int krn_row_step = kernel_width * in_ch;
     const int amount_rows = row_end - row_begin;
     const int amount_columns = clmn_end - clmn_begin;
-    const int in_compensation_row_loop = in_ch * stride_height * in_width * amount_rows;
-    const int in_compensation_clmn_loop = stride_width * in_ch * amount_columns;
-    const int out_compensation_row_loop = out_ch * out_width * amount_rows;
-    const int out_compensation_clmn_loop = out_ch * amount_columns;
+    const int in_compensation_row_loop = in.row_mem_stride * stride_height * amount_rows;
+    const int in_compensation_clmn_loop = in.col_mem_stride * stride_width * amount_columns;
+    const int out_compensation_row_loop  = out.row_mem_stride * amount_rows;
+    const int out_compensation_clmn_loop = out.col_mem_stride * amount_columns;
 
-    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = (MLI_CONV_OUT_PTR(io_T) __restrict)out_ftrs;
-    out_ptr += out_ch *                 // common coefs
-            (row_begin * out_width  +   // setup init coef for moving to row
-            clmn_begin);                // setup init coef for moving to colum;
-    MLI_PTR(io_T) __restrict in_ptr = (MLI_PTR(io_T) __restrict)in_ftrs;
-    in_ptr += in_ch * ((row_begin * stride_height - padding_top) * in_width +          // move to row
-              (clmn_begin * stride_width - padding_left));                             // move to column
+    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = out.ptr
+            + out.row_mem_stride * row_begin   // move to row
+            + out.col_mem_stride * clmn_begin; // move column
 
-    for (int out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
+    MLI_PTR(io_T) __restrict in_ptr = in.ptr
+            + in.row_mem_stride * (row_begin * stride_height - padding_top)   // move to row
+            + in.col_mem_stride * (clmn_begin * stride_width - padding_left); // move to column
+
+    for (int out_ch_idx = 0; out_ch_idx < out.ch; out_ch_idx++) {
         adjust_quant_params(&quant_params, out_ch_idx);
         const int bias_add = bias_additive(biases[out_ch_idx], 0x0, &quant_params);
         int8_t init_accum_val = 0;
         int weights_add = mli_prv_init_accu(init_accum_val);
-        MLI_PTR(w_T) __restrict w_ptr = (MLI_PTR(w_T) __restrict)weights + out_ch_idx * kernel_height 
-                * kernel_width * in_ch;
 
-        for (int in_ch_idx = 0; in_ch_idx < in_ch-1; in_ch_idx+=2) {
+        MLI_PTR(w_T) __restrict w_ptr = w.ptr +
+                w.out_ch_mem_stride * out_ch_idx; // move to filter
+
+        for (int in_ch_idx = 0; in_ch_idx < (in.ch - 1); in_ch_idx += 2) {
             weights_add = weights_additive_d(w_ptr, &weights_add, &quant_params, 
-                        kernel_width, kernel_height, krn_col_step, krn_row_step);
+                    w.kernel_width, w.kernel_height, w.col_mem_stride, w.row_mem_stride);
             w_ptr += 2;
         }
 
-        if (in_ch & 1)
-        {
-            weights_add = weights_additive(w_ptr++, weights_add, &quant_params, 
-                    kernel_width, kernel_height, krn_col_step, krn_row_step);
+        if (in.ch & 1) {
+            weights_add = weights_additive(w_ptr, weights_add, &quant_params,
+                    w.kernel_width, w.kernel_height, w.col_mem_stride, w.row_mem_stride);
+            w_ptr += 1;
         }
-        w_ptr -= in_ch;
+        w_ptr -= in.ch;
 
         for (int H_idx = row_begin; H_idx < row_end; H_idx++) {
 
@@ -611,33 +564,33 @@ static __attribute__ ((always_inline)) void convolution2D_nhwc_nopad(
             acc_T accu = mli_prv_init_accu(init_accum_val);
             for (int W_idx = clmn_begin; W_idx < clmn_end; W_idx++) {
 LOOP_PIPELINE_ENABLE
-                for (int in_ch_idx = 0; in_ch_idx < in_ch -1; in_ch_idx+=2) {
-                    dotprod2D_hwc_d<io_T, w_T, acc_T>(in_ptr, w_ptr, &accu, kernel_width, kernel_height,
-                                        in_col_step, in_row_step, krn_col_step, krn_row_step);
-                    in_ptr+= 2;
+                for (int in_ch_idx = 0; in_ch_idx < (in.ch - 1); in_ch_idx += 2) {
+                    dotprod2D_hwc_d(in_ptr, w_ptr, &accu, w.kernel_width, w.kernel_height,
+                            in.col_mem_stride, in.row_mem_stride, w.col_mem_stride, w.row_mem_stride);
+                    in_ptr += 2;
                     w_ptr += 2;
                 }
 
-                if (in_ch & 1) {
-                    accu = dotprod2D(in_ptr, w_ptr, accu, kernel_width, kernel_height,
-                                        in_col_step, in_row_step, krn_col_step, krn_row_step);
-                    in_ptr++;
-                    w_ptr++;
+                if (in.ch & 1) {
+                    accu = dotprod2D(in_ptr, w_ptr, accu, w.kernel_width, w.kernel_height,
+                            in.col_mem_stride, in.row_mem_stride, w.col_mem_stride, w.row_mem_stride);
+                    in_ptr += 1;
+                    w_ptr += 1;
                 }
                 accu += bias_add;
                 
                 // Cast result to output type, apply built-in ReLU Applying and write result
                 mli_prv_clip_relu_store_output(out_ptr, accu, &quant_params, val_min_limit, val_max_limit);
 
-                out_ptr += out_ch;
-                in_ptr += in_ch * (stride_width - 1);
-                w_ptr -= in_ch;
+                out_ptr += out.col_mem_stride;
+                in_ptr += in.col_mem_stride * stride_width - in.ch;
+                w_ptr -= in.ch;
 
                 init_accum_val = weights_add;
                 accu = mli_prv_init_accu(init_accum_val);
             } // for W_idx
-            out_ptr += out_width * out_ch - out_compensation_clmn_loop;
-            in_ptr += stride_height * in_width * in_ch - in_compensation_clmn_loop;
+            out_ptr += out.row_mem_stride - out_compensation_clmn_loop;
+            in_ptr += in.row_mem_stride * stride_height - in_compensation_clmn_loop;
         } // for H_idx
         in_ptr -=  in_compensation_row_loop;
         out_ptr += 1 - out_compensation_row_loop;
@@ -646,39 +599,31 @@ LOOP_PIPELINE_ENABLE
 
 template <typename io_T, typename w_T, typename b_T, typename acc_T>
 static __attribute__ ((always_inline)) void convolution2D_nhwc_krnpad(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        const MLI_PTR(w_T)  __restrict weights,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(w_T)> &w,
         const MLI_PTR(b_T)  __restrict biases,
-              MLI_CONV_OUT_PTR(io_T) __restrict out_ftrs,
-
+        const tensor_private_t<MLI_CONV_OUT_PTR(io_T)> &out,
         const rect_t * const perception_area,
         s8asym_quant_specific_params quant_params,
         const io_T val_min_limit,
         const io_T val_max_limit,
-
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width, const int out_height,
-        const int kernel_height, const int kernel_width,
         const int stride_height, const int stride_width,
         const int padding_top, const int padding_left,
-        const int padding_bot, const int padding_right ) {
+        const int padding_bot, const int padding_right) {
 
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
     rect_t perception_area_nopad;
     perception_area_nopad.row_beg = CEIL_DIV(padding_top, stride_height);
-    perception_area_nopad.row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+    perception_area_nopad.row_end = out.height - CEIL_DIV(padding_bot, stride_height);
     perception_area_nopad.clmn_beg = CEIL_DIV(padding_left, stride_width);
-    perception_area_nopad.clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
+    perception_area_nopad.clmn_end = out.width - CEIL_DIV(padding_right, stride_width);
 
     if ((perception_area_nopad.row_end - perception_area_nopad.row_beg > 0)
         && (perception_area_nopad.clmn_end - perception_area_nopad.clmn_beg > 0)){
         convolution2D_nhwc_nopad<int8_t, int8_t, int32_t, mli_acc32_t>(
-                in_ftrs, weights, biases, out_ftrs, &perception_area_nopad, quant_params,
+                in, w, biases, out, &perception_area_nopad, quant_params,
                 val_min_limit, val_max_limit,
-                in_ch, in_width, in_height,
-                out_ch, out_width, out_height,
-                kernel_height, kernel_width,
                 stride_height, stride_width,
                 padding_top, padding_left,
                 padding_bot, padding_right);
@@ -694,33 +639,30 @@ static __attribute__ ((always_inline)) void convolution2D_nhwc_krnpad(
             perc_areas[areas_num].row_beg = 0;
             perc_areas[areas_num].row_end = CEIL_DIV(padding_top, stride_height);
             perc_areas[areas_num].clmn_beg = 0;
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num++].clmn_end = out.width;
         }
         if (padding_bot) {
-            perc_areas[areas_num].row_beg = out_height - CEIL_DIV(padding_bot, stride_height);
-            perc_areas[areas_num].row_end = out_height;
+            perc_areas[areas_num].row_beg = out.height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].row_end = out.height;
             perc_areas[areas_num].clmn_beg = 0;
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num++].clmn_end = out.width;
         }
         if (padding_left) {
             perc_areas[areas_num].row_beg = CEIL_DIV(padding_top, stride_height);
-            perc_areas[areas_num].row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].row_end = out.height - CEIL_DIV(padding_bot, stride_height);
             perc_areas[areas_num].clmn_beg = 0;
             perc_areas[areas_num++].clmn_end = CEIL_DIV(padding_left, stride_width);
         }
         if (padding_right) {
             perc_areas[areas_num].row_beg = CEIL_DIV(padding_top, stride_height);
-            perc_areas[areas_num].row_end = out_height - CEIL_DIV(padding_bot, stride_height);
-            perc_areas[areas_num].clmn_beg = out_width - CEIL_DIV(padding_right, stride_width);
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num].row_end = out.height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].clmn_beg = out.width - CEIL_DIV(padding_right, stride_width);
+            perc_areas[areas_num++].clmn_end = out.width;
         }
         for(int i = 0; i < areas_num; i ++) {
             convolution2D_nhwc<int8_t, int8_t, int32_t, mli_acc32_t>(
-                    in_ftrs, weights, biases, out_ftrs, &perc_areas[i], quant_params,
+                    in, w, biases, out, &perc_areas[i], quant_params,
                     val_min_limit, val_max_limit,
-                    in_ch, in_width, in_height,
-                    out_ch, out_width, out_height,
-                    kernel_height, kernel_width,
                     stride_height, stride_width,
                     padding_top, padding_left,
                     padding_bot, padding_right);
@@ -730,19 +672,14 @@ static __attribute__ ((always_inline)) void convolution2D_nhwc_krnpad(
 
 template <typename io_T, typename w_T, typename b_T, typename acc_T>
 static __attribute__ ((always_inline)) void pointwise_convolution2D_nhwc_nopad(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        const MLI_PTR(w_T)  __restrict weights,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(w_T)> &w,
         const MLI_PTR(b_T)  __restrict biases,
-              MLI_CONV_OUT_PTR(io_T) __restrict out_ftrs,
-
+        const tensor_private_t<MLI_CONV_OUT_PTR(io_T)> &out,
         const rect_t * const perception_area,
         s8asym_quant_specific_params quant_params,
         const io_T val_min_limit,
         const io_T val_max_limit,
-
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width, const int out_height,
-        const int kernel_height, const int kernel_width,
         const int stride_height, const int stride_width,
         const int padding_top, const int padding_left,
         const int padding_bot, const int padding_right) {
@@ -751,63 +688,59 @@ static __attribute__ ((always_inline)) void pointwise_convolution2D_nhwc_nopad(
     const int row_end = perception_area->row_end;
     const int clmn_begin = perception_area->clmn_beg;
     const int clmn_end = perception_area->clmn_end;
-    const int krn_col_step = in_ch;
-    const int krn_row_step = in_ch;
     const int amount_rows = row_end - row_begin;
     const int amount_columns = clmn_end - clmn_begin;
-    const int in_compensation_row_loop = in_ch * stride_height * in_width * amount_rows;
-    const int in_compensation_clmn_loop = stride_width * in_ch * amount_columns;
-    const int out_compensation_row_loop = out_ch * out_width * amount_rows;
-    const int out_compensation_clmn_loop = out_ch * amount_columns;
+    const int in_compensation_row_loop   = in.row_mem_stride  * stride_height * amount_rows;
+    const int in_compensation_clmn_loop  = in.col_mem_stride  * amount_columns;
+    const int out_compensation_row_loop  = out.row_mem_stride * amount_rows;
+    const int out_compensation_clmn_loop = out.col_mem_stride * amount_columns;
 
-    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = (MLI_CONV_OUT_PTR(io_T) __restrict)out_ftrs;
-    out_ptr += out_ch *                 // common coefs
-            (row_begin * out_width  +   // setup init coef for moving to row
-            clmn_begin);                // setup init coef for moving to colum;
-    const MLI_PTR(io_T) __restrict in_ptr = (MLI_PTR(io_T) __restrict)in_ftrs;
-    in_ptr += in_ch * (row_begin * stride_height * in_width +          // move to row
-              clmn_begin * stride_width);                              // move to column
+    MLI_CONV_OUT_PTR(io_T) __restrict out_ptr = out.ptr
+            + out.row_mem_stride * row_begin   // move to row
+            + out.col_mem_stride * clmn_begin; // move to column
+    const MLI_PTR(io_T) __restrict in_ptr = in.ptr
+            + in.row_mem_stride * (row_begin * stride_height)  // move to row
+            + in.col_mem_stride * (clmn_begin * stride_width); // move to column
 
-    for (int out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
+    for (int out_ch_idx = 0; out_ch_idx < out.ch; out_ch_idx++) {
         adjust_quant_params(&quant_params, out_ch_idx);
         const int bias_add = bias_additive(biases[out_ch_idx], 0x0, &quant_params);
-        const MLI_PTR(w_T) __restrict w_ptr = (const MLI_PTR(w_T) __restrict)weights + out_ch_idx * in_ch;
+        const MLI_PTR(w_T) __restrict w_ptr = w.ptr + w.out_ch_mem_stride * out_ch_idx;
         int8_t init_accum_val = 0;
         int weights_add = mli_prv_init_accu(init_accum_val);
 
-        for (int in_ch_idx = 0; in_ch_idx < in_ch-1; in_ch_idx+=2) {
+        for (int in_ch_idx = 0; in_ch_idx < in.ch-1; in_ch_idx+=2) {
             weights_add = weights_additive_d(w_ptr, &weights_add, &quant_params, 
-                        kernel_width, kernel_height, krn_col_step, krn_row_step);
+                    w.kernel_width, w.kernel_height, w.col_mem_stride, w.row_mem_stride);
             w_ptr += 2;
         }
 
-        if (in_ch & 1)
-        {
+        if (in.ch & 1) {
             weights_add = weights_additive(w_ptr++, weights_add, &quant_params, 
-                    kernel_width, kernel_height, krn_col_step, krn_row_step);
+                    w.kernel_width, w.kernel_height, w.col_mem_stride, w.row_mem_stride);
         }
-        w_ptr -= in_ch;
+        w_ptr -= in.ch; //=w_ptr.in_ch
 
-        int odd_rest_of_in_ch = (in_ch & 0x3);
-        int even_in_ch = in_ch & (~0x3);
+        int odd_rest_of_in_ch = (in.ch & 0x3);
+        int even_in_ch = in.ch & (~0x3);
 
-        if ((in_ch & 0x3) == 0) {
+        if ((in.ch & 0x3) == 0) {
             for (int H_idx = 0; H_idx < amount_rows; H_idx++) {
 #if !defined(_ARCVER_ARCv2HS)
                 int32_t init_accum_val = weights_add;
                 acc_T accu = mli_prv_init_accu(init_accum_val);
-                for (int j = 0; j < (in_ch / 4); j++) {
+                for (int j = 0; j < (in.ch / 4); j++) {
                     mli_prv_load_mac_vec4(&accu, in_ptr, w_ptr);
-                    in_ptr += 4;
-                    w_ptr += 4;
+                    in_ptr += 4; // chan_mem_stride
+                    w_ptr += 4; // chan_mem_stride
                 }
                 accu += bias_add;
 
                 // Cast result to output type, apply built-in ReLU Applying and write result
                 mli_prv_clip_relu_store_output(out_ptr, accu, &quant_params, val_min_limit, val_max_limit);
-                out_ptr += out_ch;
-                in_ptr += in_ch * (stride_width - 1);
-                w_ptr -= in_ch;
+                out_ptr += out.col_mem_stride;
+                in_ptr += in.col_mem_stride * stride_width - in.ch;
+                w_ptr -= in.ch; //=w_ptr.in_ch
 
                 for (int W_idx = 1; W_idx < amount_columns; W_idx++) {
                     init_accum_val = weights_add;
@@ -819,21 +752,21 @@ static __attribute__ ((always_inline)) void pointwise_convolution2D_nhwc_nopad(
 #endif
 
 LOOP_PIPELINE_ENABLE
-                    for (int j = 0; j < (in_ch / 4); j++) {
+                    for (int j = 0; j < (in.ch / 4); j++) {
                         mli_prv_load_mac_vec4(&accu, in_ptr, w_ptr);
-                        in_ptr += 4;
-                        w_ptr += 4;
+                        in_ptr += 4; // chan_mem_stride
+                        w_ptr += 4;  // chan_mem_stride
                     }
                     accu += bias_add;
 
                     // Cast result to output type, apply built-in ReLU Applying and write result
                     mli_prv_clip_relu_store_output(out_ptr, accu, &quant_params, val_min_limit, val_max_limit);
-                    out_ptr += out_ch;
-                    in_ptr += in_ch * (stride_width - 1);
-                    w_ptr -= in_ch;
+                    out_ptr += out.col_mem_stride;
+                    in_ptr += in.col_mem_stride * stride_width - in.ch;
+                    w_ptr -= in.ch; //=w_ptr.in_ch
               } // for W_idx
-                out_ptr += out_width * out_ch - out_compensation_clmn_loop;
-                in_ptr += stride_height * in_width * in_ch - in_compensation_clmn_loop;
+                out_ptr += out.row_mem_stride - out_compensation_clmn_loop;
+                in_ptr += in.row_mem_stride  * stride_height - in_compensation_clmn_loop;
             } // for H_idx
         } else {
             for (int H_idx = 0; H_idx < amount_rows; H_idx++) {
@@ -845,7 +778,6 @@ LOOP_PIPELINE_ENABLE
                         mli_prv_load_mac(&accu, in_ptr++, w_ptr++);
                     }
 
-                    
 LOOP_PIPELINE_ENABLE
                     for (int j = 0; j < (even_in_ch / 4); j++) {
                         mli_prv_load_mac_vec4(&accu, in_ptr, w_ptr);
@@ -856,15 +788,15 @@ LOOP_PIPELINE_ENABLE
 
                     // Cast result to output type, apply built-in ReLU Applying and write result
                     mli_prv_clip_relu_store_output(out_ptr, accu, &quant_params, val_min_limit, val_max_limit);
-                    out_ptr += out_ch;
-                    in_ptr += in_ch * (stride_width - 1);
-                    w_ptr -= in_ch;
+                    out_ptr += out.col_mem_stride;
+                    in_ptr += in.col_mem_stride * stride_width - in.ch;
+                    w_ptr -= in.ch; //=w_ptr.in_ch
 
                     init_accum_val = weights_add;
                     accu = mli_prv_init_accu(init_accum_val);
                 } // for W_idx
-                out_ptr += out_width * out_ch - out_compensation_clmn_loop;
-                in_ptr += stride_height * in_width * in_ch - in_compensation_clmn_loop;
+                out_ptr += out.row_mem_stride - out_compensation_clmn_loop;
+                in_ptr += in.row_mem_stride  * stride_height - in_compensation_clmn_loop;
             } // for H_idx
         }
         in_ptr -=  in_compensation_row_loop;

--- a/lib/src/kernels/convolution/mli_krn_conv2d_hwc_fx16.cc
+++ b/lib/src/kernels/convolution/mli_krn_conv2d_hwc_fx16.cc
@@ -21,74 +21,67 @@ extern "C" {
 #endif
 
 #pragma Code(".mli_lib")
-/**
- * Function Short Description
- *
- * \param[in]
- * \param[in/out]
- * \param[out]
- * \result
- *
- * Some Details
- */
 
-static inline void convolution_hwc_no_pad (
-        const MLI_PTR (int16_t) __restrict in_ftrs,
-        const MLI_PTR (int16_t) __restrict weights,
+static void convolution_hwc_no_pad (
+        const tensor_private_t<MLI_PTR(int16_t)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(int16_t)> &w,
         const MLI_PTR (int16_t) __restrict biases,
-        MLI_CONV_OUT_PTR (int16_t) __restrict out_ftrs,
+        const tensor_private_t<MLI_CONV_OUT_PTR(int16_t)> &out,
         const rect_t * const perception_area,
         const int bias_shift,
         const int out_shift,
         const int16_t val_min_limit,
         const int16_t val_max_limit,
-        const int in_ch, const int in_width,
-        const int out_ch, const int out_width,
-        const int kernel_height, const int kernel_width,
-        const int stride_height, const int stride_width, 
+        const int stride_height, const int stride_width,
         const int padding_top, const int padding_left);
 
 static inline void convolution_hwc_no_pad_unroll4 (
-        const MLI_PTR (int16_t) __restrict in_ftrs,
-        const MLI_PTR (int16_t) __restrict weights,
+        const tensor_private_t<MLI_PTR(int16_t)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(int16_t)> &w,
         const MLI_PTR (int16_t) __restrict biases,
-        MLI_CONV_OUT_PTR (int16_t) __restrict out_ftrs,
+        const tensor_private_t<MLI_CONV_OUT_PTR(int16_t)> &out,
         const rect_t * const perception_area,
         const int bias_shift,
         const int out_shift,
         const int16_t val_min_limit,
         const int16_t val_max_limit,
-        const int in_ch, const int in_width,
-        const int out_ch, const int out_width,
-        const int kernel_height, const int kernel_width,
         const int stride_height, const int stride_width, 
         const int padding_top, const int padding_left);
 
 static void convolution_hwc (
-        const MLI_PTR (int16_t) __restrict in_ftrs,
-        const MLI_PTR (int16_t) __restrict weights,
+        const tensor_private_t<MLI_PTR(int16_t)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(int16_t)> &w,
         const MLI_PTR (int16_t) __restrict biases,
-        MLI_CONV_OUT_PTR (int16_t) __restrict out_ftrs,
+        const tensor_private_t<MLI_CONV_OUT_PTR(int16_t)> &out,
         const rect_t * const perception_area,
         const int bias_shift,
         const int out_shift,
         const int16_t val_min_limit,
         const int16_t val_max_limit,
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width,
-        const int kernel_height, const int kernel_width, 
         const int stride_height, const int stride_width, 
         const int padding_top, const int padding_left);
 
+static mli_status mli_krn_conv2d_hwc_fx16_1x1_str1_nopad (
+        const mli_tensor * in,
+        const mli_tensor * weights,
+        const mli_tensor * bias,
+        const mli_conv2d_cfg * cfg,
+        mli_tensor * out);
+
 mli_status mli_krn_conv2d_hwc_fx16 (
-        const mli_tensor * in, 
-        const mli_tensor * weights, 
-        const mli_tensor * bias, 
-        const mli_conv2d_cfg * cfg, 
+        const mli_tensor * in,
+        const mli_tensor * weights,
+        const mli_tensor * bias,
+        const mli_conv2d_cfg * cfg,
         mli_tensor * out) {
+
     mli_status ret = MLI_CHECK_STATUS(mli_chk_conv2d_hwc(in, weights, bias, cfg, out), __func__);
     if (ret != MLI_STATUS_OK)
             return ret;
+
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in);
+    const auto w = mli_prv_get_conv2d_weights_tensor_nhwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(weights);
+    __builtin_assume(in_prv.ch == w.in_ch);
 
     mli_prv_fx_init_dsp_ctrl();
 
@@ -99,55 +92,49 @@ mli_status mli_krn_conv2d_hwc_fx16 (
     uint8_t padding_left = cfg->padding_left;
     uint8_t padding_right = cfg->padding_right;
 
+    if (w.kernel_height == 1 && w.kernel_width == 1 && cfg->stride_height == 1 && cfg->stride_width == 1 &&
+        (padding_top == 0 & padding_bot == 0 & padding_left == 0 & padding_right == 0))
+        return mli_krn_conv2d_hwc_fx16_1x1_str1_nopad(in, weights, bias, cfg, out);
+
     mli_minmax_t val_limit;
     out->el_type = MLI_EL_FX_16;
     // Define output val limits - we need it in case built-in RELU
     val_limit = mli_prv_get_relu_min_max (&cfg->relu, out);
 
-    MLI_PTR (int16_t) in_ftrs = (MLI_PTR (int16_t)) in->data;
     MLI_CONV_OUT_PTR (int16_t) out_ftrs = (MLI_CONV_OUT_PTR (int16_t)) out->data;
-    MLI_PTR (int16_t) wt = (MLI_PTR (int16_t)) weights->data;
     MLI_PTR (int16_t) bs = (MLI_PTR (int16_t)) bias->data;
 
-    int in_ch = (int) in->shape[2];
-    int out_ch = (int) weights->shape[0];
-
-    int kernel_height = (int) weights->shape[1];
-    int kernel_width = (int) weights->shape[2];
-
-    int in_height = (int) in->shape[0];
-    int in_width = (int) in->shape[1];
-
-    int out_width = (in_width + padding_left + padding_right - kernel_width + 1);
-            out_width = (out_width % stride_width != 0) ? (out_width / stride_width + 1) : out_width / stride_width;
-
-    int out_height = (in_height + padding_top + padding_bot - kernel_height + 1);
-            out_height = (out_height % stride_height != 0) ? (out_height / stride_height + 1) : out_height / stride_height;
+    int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
     uint8_t bias_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits) - bias->el_params.fx.frac_bits;
     uint8_t out_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits) - out->el_params.fx.frac_bits;
 
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[0] = out_height;
+    out->shape[1] = out_width;
+    out->shape[2] = w.out_ch;
+
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int16_t), MLI_CONV_OUT_PTR_IS_XY>(out);
+
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
-    if (in_height >= kernel_height && in_width >= kernel_width) {
+    if (in_prv.height >= w.kernel_height && in_prv.width >= w.kernel_width) {
         rect_t cent_area;
-            cent_area.row_beg = (padding_top % stride_height != 0) ? (padding_top / stride_height + 1) 
-                    : padding_top / stride_height;
-            cent_area.row_end = out_height - ((padding_bot % stride_height != 0) ? (padding_bot / stride_height + 1) 
-                    : padding_bot / stride_height);
-            cent_area.clmn_beg = (padding_left % stride_width != 0) ? (padding_left / stride_width + 1) 
-                    : padding_left / stride_width;
-            cent_area.clmn_end = out_width - ((padding_right % stride_width != 0) ? (padding_right / stride_width + 1) 
-                    : padding_right / stride_width);
+        cent_area.row_beg = CEIL_DIV(padding_top, stride_height);
+        cent_area.row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+        cent_area.clmn_beg = CEIL_DIV(padding_left, stride_width);
+        cent_area.clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
 
-            convolution_hwc_no_pad (in_ftrs, wt, bs, out_ftrs, &cent_area, bias_shift, out_shift,
-                                    val_limit.min, val_limit.max, in_ch, in_width, out_ch, out_width,
-                                    kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_left);
+        convolution_hwc_no_pad (in_prv, w, bs, out_prv, &cent_area, bias_shift, out_shift,
+                val_limit.min, val_limit.max,
+                stride_height, stride_width, padding_top, padding_left);
     }
     // Phase 2: Process border part with more complex algorithm
     // (usually significantly smaller part of computations)
     //=======================================================================//
-        if (padding_top || padding_left || padding_bot || padding_right) {
+    if (padding_top || padding_left || padding_bot || padding_right) {
         rect_t perc_areas[4];
         int areas_num = 0;
         if (padding_top) {
@@ -176,31 +163,30 @@ mli_status mli_krn_conv2d_hwc_fx16 (
         }
         // Iterating over perception areas and perform general convolution per each
         for (int area_idx = 0; area_idx < areas_num; area_idx++) {
-            convolution_hwc (in_ftrs, wt, bs, out_ftrs, &perc_areas[area_idx], bias_shift, out_shift,
-                    val_limit.min, val_limit.max, in_ch, in_width, in_height, out_ch, out_width,
-                    kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_left);
+            convolution_hwc (in_prv, w, bs, out_prv, &perc_areas[area_idx], bias_shift, out_shift,
+                    val_limit.min, val_limit.max,
+                    stride_height, stride_width, padding_top, padding_left);
         }
     }
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[0] = out_height;
-    out->shape[1] = out_width;
-    out->shape[2] = out_ch;
 
     return MLI_STATUS_OK;
 }
 
-mli_status mli_krn_conv2d_hwc_fx16_1x1_str1_nopad (
-        const mli_tensor * in, 
-        const mli_tensor * weights, 
+static mli_status mli_krn_conv2d_hwc_fx16_1x1_str1_nopad (
+        const mli_tensor * in,
+        const mli_tensor * weights,
         const mli_tensor * bias, 
-        const mli_conv2d_cfg * cfg, 
+        const mli_conv2d_cfg * cfg,
         mli_tensor * out) {
     mli_status ret = MLI_CHECK_STATUS(mli_chk_conv2d_hwc(in, weights, bias, cfg, out), __func__);
     if (ret != MLI_STATUS_OK)
         return ret;
 
     mli_prv_fx_init_dsp_ctrl();
+
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in);
+    auto w = mli_prv_get_conv2d_weights_tensor_nhwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(weights);
+    __builtin_assume(in_prv.ch == w.in_ch);
 
     uint8_t stride_width = cfg->stride_width;
     uint8_t stride_height = cfg->stride_height;
@@ -209,6 +195,8 @@ mli_status mli_krn_conv2d_hwc_fx16_1x1_str1_nopad (
     uint8_t padding_left = cfg->padding_left;
     uint8_t padding_right = cfg->padding_right;
 
+    MLI_ASSERT(w.kernel_width == 1);
+    MLI_ASSERT(w.kernel_height == 1);
     MLI_ASSERT(stride_width == 1);
     MLI_ASSERT(stride_height == 1);
     MLI_ASSERT(padding_top == 0);
@@ -216,6 +204,8 @@ mli_status mli_krn_conv2d_hwc_fx16_1x1_str1_nopad (
     MLI_ASSERT(padding_left == 0);
     MLI_ASSERT(padding_right == 0);
 
+    w.kernel_width = 1;
+    w.kernel_height = 1;
     stride_width = 1;
     stride_height = 1;
     padding_top = 0;
@@ -228,26 +218,17 @@ mli_status mli_krn_conv2d_hwc_fx16_1x1_str1_nopad (
     // Define output val limits - we need it in case built-in RELU
     val_limit = mli_prv_get_relu_min_max (&cfg->relu, out);
 
-    MLI_PTR (int16_t) in_ftrs = (MLI_PTR (int16_t)) in->data;
-    MLI_CONV_OUT_PTR (int16_t) out_ftrs = (MLI_CONV_OUT_PTR (int16_t)) out->data;
-    MLI_PTR (int16_t) wt = (MLI_PTR (int16_t)) weights->data;
     MLI_PTR (int16_t) bs = (MLI_PTR (int16_t)) bias->data;
 
-    int in_ch = (int) in->shape[2];
-    int out_ch = (int) weights->shape[0];
+    int out_width = (in_prv.width + padding_left + padding_right - w.kernel_width + 1);
+    int out_height = (in_prv.height + padding_top + padding_bot - w.kernel_height + 1);
 
-    int kernel_height = (int) weights->shape[1];
-    int kernel_width = (int) weights->shape[2];
-    MLI_ASSERT(kernel_width == 1);
-    MLI_ASSERT(kernel_height == 1);
-    kernel_width = 1;
-    kernel_height = 1;
-
-    int in_height = (int) in->shape[0];
-    int in_width = (int) in->shape[1];
-
-    int out_width = (in_width + padding_left + padding_right - kernel_width + 1);
-    int out_height = (in_height + padding_top + padding_bot - kernel_height + 1);
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[0] = out_height;
+    out->shape[1] = out_width;
+    out->shape[2] = w.out_ch;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int16_t), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     uint8_t bias_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits) - bias->el_params.fx.frac_bits;
     uint8_t out_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits) - out->el_params.fx.frac_bits;
@@ -258,15 +239,9 @@ mli_status mli_krn_conv2d_hwc_fx16_1x1_str1_nopad (
     cent_area.clmn_beg = 0;
     cent_area.clmn_end = out_width;
 
-    convolution_hwc_no_pad_unroll4 (in_ftrs, wt, bs, out_ftrs, &cent_area, bias_shift, out_shift,
-            val_limit.min, val_limit.max, in_ch, in_width, out_ch, out_width,
-            kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_left);
-
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[0] = out_height;
-    out->shape[1] = out_width;
-    out->shape[2] = out_ch;
+    convolution_hwc_no_pad_unroll4 (in_prv, w, bs, out_prv, &cent_area, bias_shift, out_shift,
+            val_limit.min, val_limit.max,
+            stride_height, stride_width, padding_top, padding_left);
 
     return MLI_STATUS_OK;
 }
@@ -286,124 +261,136 @@ mli_status mli_krn_conv2d_hwc_fx16_1x1_str1_nopad (
  * Targets:
  *
  ******************************************************************************/
-
+__attribute__((always_inline))
 static inline void convolution_hwc_no_pad (
-        const MLI_PTR (int16_t) __restrict in_ftrs,
-        const MLI_PTR (int16_t) __restrict weights,
+        const tensor_private_t<MLI_PTR(int16_t)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(int16_t)> &w,
         const MLI_PTR (int16_t) __restrict biases,
-        MLI_CONV_OUT_PTR (int16_t) __restrict out_ftrs,
+        const tensor_private_t<MLI_CONV_OUT_PTR(int16_t)> &out,
         const rect_t * const perception_area,
         const int bias_shift,
         const int out_shift,
         const int16_t val_min_limit,
         const int16_t val_max_limit,
-        const int in_ch, const int in_width,
-        const int out_ch, const int out_width,
-        const int kernel_height, const int kernel_width,
-        const int stride_height, const int stride_width, 
+        const int stride_height, const int stride_width,
         const int padding_top, const int padding_left) {
     const int row_begin = perception_area->row_beg;
     const int row_end = perception_area->row_end;
     const int clmn_begin = perception_area->clmn_beg;
     const int clmn_end = perception_area->clmn_end;
+    const int out_ch_mem_stride = 1;
 
     for (int H_idx = row_begin; H_idx < row_end; H_idx++) {
-        const MLI_PTR (int16_t) in_ptr = in_ftrs +  // starting point
-            in_ch * in_width * (H_idx * stride_height - padding_top) +  // move to row
-            in_ch * (clmn_begin * stride_width - padding_left); // move to column
-        int W_idx_inc = in_ch * stride_width;
+        const MLI_PTR (int16_t) in_ptr = in.ptr
+                + in.row_mem_stride * (H_idx * stride_height - padding_top) +     // move to row
+                + in.col_mem_stride * (clmn_begin * stride_width - padding_left); // move to column
+
+        MLI_CONV_OUT_PTR (int16_t) o_ptr = out.ptr
+                + out.row_mem_stride  * H_idx
+                + out.col_mem_stride * clmn_begin;
 
         for (int W_idx = clmn_begin; W_idx < clmn_end; W_idx++) {
-            MLI_CONV_OUT_PTR (int16_t) o_ptr = out_ftrs + (H_idx * out_width + W_idx) * out_ch;
+            const MLI_PTR (int16_t) w_ptr = w.ptr; // Start point
 
-            const MLI_PTR (int16_t) w_ptr = weights;    // Start point
-            int w_ptr_inc = in_ch * kernel_width * kernel_height;   // move to filter
-            for (int out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
-
-                auto conv_out = mli_prv_init_accu_with_bias (in_ftrs, biases[out_ch_idx], bias_shift);
+            for (int out_ch_idx = 0; out_ch_idx < w.out_ch; out_ch_idx++) {
+                auto accu = mli_prv_init_accu_with_bias (in.ptr, biases[out_ch_idx], bias_shift);
 
                 // Convolution core
-                dotprod2D (in_ptr, w_ptr, kernel_width * in_ch, kernel_height, in_width * in_ch, kernel_width * in_ch, 
-                        &conv_out);
+                for (int in_ch_idx = 0; in_ch_idx < (in.ch - 1); in_ch_idx += 2) {
+                    dotprod2D_hwc_d(in_ptr, w_ptr, &accu, w.kernel_width, w.kernel_height,
+                            in.col_mem_stride, in.row_mem_stride,
+                            w.col_mem_stride, w.row_mem_stride);
+                    in_ptr += 2;
+                    w_ptr += 2;
+                }
 
-                mli_prv_clip_relu_store_output (o_ptr, conv_out, out_shift, val_min_limit, val_max_limit);
-                o_ptr++;
-                w_ptr += w_ptr_inc;
-            }               // out_ch_idx
-            in_ptr += W_idx_inc;
-        }                   // W_idx
+                if (in.ch & 1) {
+                    accu = dotprod2D(in_ptr, w_ptr, accu, w.kernel_width, w.kernel_height,
+                            in.col_mem_stride, in.row_mem_stride,
+                            w.col_mem_stride, w.row_mem_stride);
+                    in_ptr += 1;
+                    w_ptr += 1;
+                }
+                in_ptr -= in.ch;
+                w_ptr -= in.ch;
+
+                mli_prv_clip_relu_store_output (o_ptr, accu, out_shift, val_min_limit, val_max_limit);
+                o_ptr += out_ch_mem_stride;
+                w_ptr += w.out_ch_mem_stride;
+            } // out_ch_idx
+            o_ptr += out.col_mem_stride - w.out_ch * out_ch_mem_stride;
+            in_ptr += in.col_mem_stride * stride_width;
+        } // W_idx
     }
 }
 
+__attribute__((always_inline))
 static inline void convolution_hwc_no_pad_unroll4 (
-        const MLI_PTR (int16_t) __restrict in_ftrs,
-        const MLI_PTR (int16_t) __restrict weights,
+        const tensor_private_t<MLI_PTR(int16_t)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(int16_t)> &w,
         const MLI_PTR (int16_t) __restrict biases,
-        MLI_CONV_OUT_PTR (int16_t) __restrict out_ftrs,
+        const tensor_private_t<MLI_CONV_OUT_PTR(int16_t)> &out,
         const rect_t * const perception_area,
         const int bias_shift,
         const int out_shift,
         const int16_t val_min_limit,
         const int16_t val_max_limit,
-        const int in_ch, const int in_width,
-        const int out_ch, const int out_width,
-        const int kernel_height, const int kernel_width,
-        const int stride_height, const int stride_width, 
+        const int stride_height, const int stride_width,
         const int padding_top, const int padding_left) {
     const int row_begin = perception_area->row_beg;
     const int row_end = perception_area->row_end;
     const int clmn_begin = perception_area->clmn_beg;
     const int clmn_end = perception_area->clmn_end;
+    const int out_ch_mem_stride = 1;
 
     for (int H_idx = row_begin; H_idx < row_end; H_idx++) {
-        const MLI_PTR (int16_t) in_ptr = in_ftrs +  // starting point
-                in_ch * in_width * (H_idx * stride_height - padding_top) +  // move to row
-                in_ch * (clmn_begin * stride_width - padding_left); // move to column
-        int W_idx_inc = in_ch * stride_width;
+        const MLI_PTR (int16_t) in_ptr = in.ptr
+                + in.row_mem_stride * (H_idx * stride_height - padding_top)       // move to row
+                + in.col_mem_stride * (clmn_begin * stride_width - padding_left); // move to column
 
         for (int W_idx = clmn_begin; W_idx < clmn_end; W_idx++) {
-            MLI_CONV_OUT_PTR (int16_t) o_ptr = out_ftrs + (H_idx * out_width + W_idx) * out_ch;
+            MLI_CONV_OUT_PTR (int16_t) o_ptr = out.ptr
+                    + out.row_mem_stride  * H_idx
+                    + out.col_mem_stride * W_idx;
 
-            const MLI_PTR (int16_t) w_ptr = weights;    // Start point
-            int w_ptr_inc = in_ch * kernel_width * kernel_height;   // move to filter
-            for (int out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
+            const MLI_PTR (int16_t) w_ptr = w.ptr; // Start point
 
+            for (int out_ch_idx = 0; out_ch_idx < w.out_ch; out_ch_idx++) {
                 auto conv_out = mli_prv_init_accu_with_bias (in_ptr, biases[out_ch_idx], bias_shift);
 
                 int unroll4_mask = 0x3;
-                int rounded_count = (kernel_width * in_ch) & ~unroll4_mask;
-                int remainder_count = (kernel_width * in_ch) & unroll4_mask;
+                int rounded_count = (w.kernel_width * in.ch) & ~unroll4_mask;
+                int remainder_count = (w.kernel_width * in.ch) & unroll4_mask;
 
                 // Convolution core
-                dotprod2D_unroll4 (in_ptr, w_ptr, rounded_count, kernel_height, in_width * in_ch, kernel_width * in_ch, 
-                        &conv_out);
+                dotprod2D_unroll4 (in_ptr, w_ptr, rounded_count, w.kernel_height,
+                        in.row_mem_stride, w.row_mem_stride, &conv_out);
 
                 if (remainder_count) {
-                    dotprod2D (in_ptr + rounded_count, w_ptr + rounded_count, remainder_count, kernel_height, 
-                            in_width * in_ch, kernel_width * in_ch, &conv_out);
+                    dotprod2D (in_ptr + rounded_count, w_ptr + rounded_count, remainder_count, w.kernel_height,
+                            in.row_mem_stride, w.row_mem_stride, &conv_out);
                 }
 
                 mli_prv_clip_relu_store_output (o_ptr, conv_out, out_shift, val_min_limit, val_max_limit);
-                o_ptr++;
-                w_ptr += w_ptr_inc;
-            }               // out_ch_idx
-            in_ptr += W_idx_inc;
-        }                   // W_idx
-    }
+                o_ptr += out_ch_mem_stride;
+                w_ptr += w.out_ch_mem_stride;
+            } // out_ch_idx
+            in_ptr += in.col_mem_stride * stride_width;
+        } // W_idx
+    } // H_idx
 }
+
+__attribute__((noinline))
 static void convolution_hwc (
-        const MLI_PTR (int16_t) __restrict in_ftrs,
-        const MLI_PTR (int16_t) __restrict weights,
+        const tensor_private_t<MLI_PTR(int16_t)> &in,
+        const conv2d_weights_tensor_private_t<MLI_PTR(int16_t)> &w,
         const MLI_PTR (int16_t) __restrict biases,
-        MLI_CONV_OUT_PTR (int16_t) __restrict out_ftrs,
+        const tensor_private_t<MLI_CONV_OUT_PTR(int16_t)> &out,
         const rect_t * const perception_area,
         const int bias_shift,
         const int out_shift,
         const int16_t val_min_limit,
         const int16_t val_max_limit,
-        const int in_ch, const int in_width, const int in_height,
-        const int out_ch, const int out_width,
-        const int kernel_height, const int kernel_width, 
         const int stride_height, const int stride_width, 
         const int padding_top, const int padding_left) {
 
@@ -412,39 +399,57 @@ static void convolution_hwc (
     const int clmn_begin = perception_area->clmn_beg;
     const int clmn_end = perception_area->clmn_end;
 
-    for (int out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
+    for (int out_ch_idx = 0; out_ch_idx < w.out_ch; out_ch_idx++) {
         for (int H_idx = row_begin; H_idx < row_end; H_idx++) {
             for (int W_idx = clmn_begin; W_idx < clmn_end; W_idx++) {
-                auto conv_out = mli_prv_init_accu_with_bias (in_ftrs, biases[out_ch_idx], bias_shift);
+                auto accu = mli_prv_init_accu_with_bias (in.ptr, biases[out_ch_idx], bias_shift);
 
                 // Define area of input and filter for convolution
                 // *_comp - compensation values for valid area defining
                 int top_comp = -MIN ((H_idx * stride_height) - padding_top, 0);
                 int left_comp = -MIN ((W_idx * stride_width) - padding_left, 0);
 
-                int right_comp = -MIN (in_width - ((W_idx * stride_width) 
-                        - padding_left + kernel_width), 0);
-                int bottom_comp = -MIN (in_height - ((H_idx * stride_height) 
-                        - padding_top + kernel_height), 0);
+                int right_comp = -MIN (in.width - ((W_idx * stride_width)
+                        - padding_left + w.kernel_width), 0);
+                int bottom_comp = -MIN (in.height - ((H_idx * stride_height)
+                        - padding_top + w.kernel_height), 0);
 
-                int rows = kernel_height - top_comp - bottom_comp;
-                int clmns = kernel_width - right_comp - left_comp;
+                int rows = w.kernel_height - top_comp - bottom_comp;
+                int clmns = w.kernel_width - right_comp - left_comp;
 
-                const MLI_PTR (int16_t) in_ptr = in_ftrs +  // starting point
-                        in_ch * in_width * (H_idx * stride_height - padding_top + top_comp) +   // move to row
-                        in_ch * ((W_idx * stride_width) - padding_left + left_comp);    // move to column
+                const MLI_PTR (int16_t) in_ptr = in.ptr
+                        + in.col_mem_stride * (W_idx * stride_width - padding_left + left_comp) // move to column
+                        + in.row_mem_stride * (H_idx * stride_height - padding_top + top_comp); // move to row
 
-                const MLI_PTR (int16_t) w_ptr = weights +   // Start point
-                        out_ch_idx * in_ch * kernel_width * kernel_height + // move to filter
-                        top_comp * kernel_width * in_ch +   // move to row
-                        left_comp * in_ch;  // move to column
+                const MLI_PTR (int16_t) w_ptr = w.ptr
+                        + w.col_mem_stride * left_comp      // move to column
+                        + w.row_mem_stride * top_comp       // move to row
+                        + w.out_ch_mem_stride * out_ch_idx; // move to filter
 
                 // Convolution core
-                dotprod2D (in_ptr, w_ptr, clmns * in_ch, rows, in_width * in_ch,
-                         kernel_width * in_ch, &conv_out);
+                for (int in_ch_idx = 0; in_ch_idx < in.ch - 1; in_ch_idx += 2) {
+                    dotprod2D_hwc_d (in_ptr, w_ptr, &accu, clmns, rows,
+                            in.col_mem_stride, in.row_mem_stride, 
+                            w.col_mem_stride, w.row_mem_stride);
+                    in_ptr += 2;
+                    w_ptr += 2;
+                }
 
-                MLI_CONV_OUT_PTR(int16_t) o_ptr = &out_ftrs[out_ch_idx + (H_idx * out_width + W_idx) * out_ch];
-                mli_prv_clip_relu_store_output (o_ptr, conv_out, out_shift, val_min_limit, val_max_limit);
+                if (in.ch & 1) {
+                    accu = dotprod2D (in_ptr, w_ptr, accu, clmns, rows,
+                            in.col_mem_stride, in.row_mem_stride,
+                            w.col_mem_stride, w.row_mem_stride);
+                    in_ptr += 1;
+                    w_ptr += 1;
+                }
+                in_ptr -= in.ch;
+                w_ptr -= in.ch;
+
+                MLI_CONV_OUT_PTR(int16_t) o_ptr = out.ptr
+                        + out.col_mem_stride * W_idx
+                        + out.row_mem_stride * H_idx
+                        + out_ch_idx;
+                mli_prv_clip_relu_store_output (o_ptr, accu, out_shift, val_min_limit, val_max_limit);
             }
         }
     }

--- a/lib/src/kernels/convolution/mli_krn_conv2d_hwc_fx8.cc
+++ b/lib/src/kernels/convolution/mli_krn_conv2d_hwc_fx8.cc
@@ -18,30 +18,13 @@
 #include "mli_math_macros.h"
 #include "mli_private_types.h"
 #include "mli_prv_dsp.h"
+#include "mli_krn_dotprod.h"
 
-/**
- * Function Short Description
- *
- * \param[in]
- * \param[in/out]
- * \param[out]
- * \result
- *
- * Some Details
- */
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #pragma Code(".mli_lib")
-
-static inline int32_t dotprod2D (
-        int8_t * in, 
-        int8_t * krn, 
-        uint32_t width, 
-        uint32_t height, 
-        uint32_t in_row_step, 
-        uint32_t kern_row_step);
 
 mli_status mli_krn_conv2d_hwc_fx8 (
         const mli_tensor * in, 
@@ -66,67 +49,71 @@ mli_status mli_krn_conv2d_hwc_fx8 (
     out->el_type = MLI_EL_FX_8;
     // Define output val limits - we need it in case built-in RELU
     val_limit = mli_prv_get_relu_min_max (&cfg->relu, out);
-
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t))in->data;
-    MLI_CONV_OUT_PTR(int8_t) out_ftrs = (MLI_CONV_OUT_PTR(int8_t))out->data;
-    MLI_PTR(int8_t) wt = (MLI_PTR(int8_t))weights->data;
     MLI_PTR(int8_t) bs = (MLI_PTR(int8_t))bias->data;
 
-    uint16_t in_ch = in->shape[2];
-    uint16_t out_ch = weights->shape[0];
-
-    uint16_t kernel_height = weights->shape[1];
-    uint16_t kernel_width = weights->shape[2];
-
-    uint16_t in_height = in->shape[0];
-    uint16_t in_width = in->shape[1];
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in);
+    const auto w = mli_prv_get_conv2d_weights_tensor_nhwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(weights);
+    __builtin_assume(in_prv.ch == w.in_ch);
 
     //
-    uint16_t out_width = (in_width + padding_left + padding_right - kernel_width + 1);
-    out_width = (out_width % stride_width != 0) ? (out_width / stride_width + 1) 
-            : out_width / stride_width;
+    uint16_t out_width = CEIL_DIV (in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    uint16_t out_height = CEIL_DIV (in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-    uint16_t out_height = (in_height + padding_top + padding_bot - kernel_height + 1);
-    out_height = (out_height % stride_height != 0) ? (out_height / stride_height + 1) 
-            : out_height / stride_height;
-
-    uint8_t bias_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits) 
+    uint8_t bias_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits)
             - bias->el_params.fx.frac_bits;
-    uint8_t out_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits) 
+    uint8_t out_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits)
             - out->el_params.fx.frac_bits;
+
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[0] = out_height;
+    out->shape[1] = out_width;
+    out->shape[2] = w.out_ch;
+
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int8_t), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
-    if (in_height >= kernel_height && in_width >= kernel_width) {
+    if (in_prv.height >= w.kernel_height && in_prv.width >= w.kernel_width) {
         rect_t cent_area;
-        cent_area.row_beg = (padding_top % stride_height != 0) ? (padding_top / stride_height + 1) 
-                : padding_top / stride_height;
-        cent_area.row_end = out_height - ((padding_bot % stride_height != 0) ? (padding_bot / stride_height + 1) 
-                : padding_bot / stride_height);
-        cent_area.clmn_beg = (padding_left % stride_width != 0) ? (padding_left / stride_width + 1) 
-                : padding_left / stride_width;
-        cent_area.clmn_end = out_width - ((padding_right % stride_width != 0) ? (padding_right / stride_width + 1) 
-                : padding_right / stride_width);
-        for (uint32_t out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
+        cent_area.row_beg = CEIL_DIV (padding_top, stride_height);
+        cent_area.row_end = out_height - CEIL_DIV (padding_bot, stride_height);
+        cent_area.clmn_beg = CEIL_DIV (padding_left, stride_width);
+        cent_area.clmn_end = out_width - CEIL_DIV (padding_right, stride_width);
+
+        for (uint32_t out_ch_idx = 0; out_ch_idx < w.out_ch; out_ch_idx++) {
             for (uint32_t H_idx = cent_area.row_beg; H_idx < cent_area.row_end; H_idx++) {
                 for (uint32_t W_idx = cent_area.clmn_beg; W_idx < cent_area.clmn_end; W_idx++) {
-                    auto conv_out = mli_prv_init_accu_with_bias (in_ftrs, bs[out_ch_idx], bias_shift);
+                    auto accu = mli_prv_init_accu_with_bias (in_prv.ptr, bs[out_ch_idx], bias_shift);
 
                     // Define area of input and filter for convolution
+                    const MLI_PTR (int8_t) in_ptr = in_prv.ptr +                         // starting point
+                        in_prv.row_mem_stride * (H_idx * stride_height - padding_top) +  // move to row
+                        in_prv.col_mem_stride * (W_idx * stride_width - padding_left);   // move to column
 
-                    int8_t *in_ptr = in_ftrs +  // starting point
-                            in_ch * in_width * (H_idx * stride_height - padding_top) +  // move to row
-                            in_ch * (W_idx * stride_width - padding_left);  // move to column
-
-                    int8_t *w_ptr = wt +    // Start point
-                            out_ch_idx * in_ch * kernel_width * kernel_height;  // move to filter
+                    const MLI_PTR(int8_t) w_ptr = w.ptr +     // Start point
+                            w.out_ch_mem_stride * out_ch_idx; // move to filter
 
                     // Convolution core
-                    conv_out += dotprod2D (in_ptr, w_ptr, kernel_width * in_ch, kernel_height, in_width * in_ch, 
-                            kernel_width * in_ch);
+                    for (int in_ch_idx = 0; in_ch_idx < in_prv.ch - 1; in_ch_idx += 2) {
+                        dotprod2D_hwc_d (in_ptr, w_ptr, &accu, w.kernel_width, w.kernel_height,
+                                in_prv.col_mem_stride, in_prv.row_mem_stride,
+                                w.col_mem_stride, w.row_mem_stride);
+                        in_ptr += 2;
+                        w_ptr += 2;
+                    }
 
-                    MLI_CONV_OUT_PTR(int8_t) o_ptr = &out_ftrs[out_ch_idx + (H_idx * out_width + W_idx) * out_ch];
-                    mli_prv_clip_relu_store_output (o_ptr, conv_out, out_shift, val_limit.min, val_limit.max);
+                    if (in_prv.ch & 1) {
+                        accu = dotprod2D (in_ptr, w_ptr, accu, w.kernel_width, w.kernel_height,
+                                in_prv.col_mem_stride, in_prv.row_mem_stride,
+                                w.col_mem_stride, w.row_mem_stride);
+                        in_ptr += 1;
+                        w_ptr += 1;
+                    }
+                    MLI_CONV_OUT_PTR(int8_t) o_ptr = &out_prv.ptr[out_ch_idx +
+                        (out_prv.row_mem_stride * H_idx) +
+                        (out_prv.col_mem_stride * W_idx)];
+                    mli_prv_clip_relu_store_output (o_ptr, accu, out_shift, val_limit.min, val_limit.max);
                 }
             }
         }
@@ -163,70 +150,64 @@ mli_status mli_krn_conv2d_hwc_fx8 (
         }
 
         for (uint32_t area_idx = 0; area_idx < areas_num; ++area_idx) {
-            for (uint32_t out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
+            for (uint32_t out_ch_idx = 0; out_ch_idx < w.out_ch; out_ch_idx++) {
                 for (uint32_t H_idx = perc_areas[area_idx].row_beg; H_idx < perc_areas[area_idx].row_end; H_idx++) {
                     for (uint32_t W_idx = perc_areas[area_idx].clmn_beg; W_idx < perc_areas[area_idx].clmn_end; W_idx++) {
-                        auto conv_out = mli_prv_init_accu_with_bias (in_ftrs, bs[out_ch_idx], bias_shift);
+                        auto accu = mli_prv_init_accu_with_bias (in_prv.ptr, bs[out_ch_idx], bias_shift);
 
                         // Define area of input and filter for convolution
                         // *_comp - compensation values for valid area defining
                         int32_t top_comp = -MIN ((int32_t) (H_idx * stride_height) - padding_top, 0);
                         int32_t left_comp = -MIN ((int32_t) (W_idx * stride_width) - padding_left, 0);
 
-                        int32_t right_comp = -MIN ((int32_t) in_width - ((int32_t) (W_idx * stride_width) 
-                                - padding_left + kernel_width), 0);
-                        int32_t bottom_comp = -MIN ((int32_t) in_height - ((int32_t) (H_idx * stride_height) 
-                                - padding_top + kernel_height), 0);
+                        int32_t right_comp = -MIN ((int32_t) in_prv.width - ((int32_t) (W_idx * stride_width)
+                                - padding_left + w.kernel_width), 0);
+                        int32_t bottom_comp = -MIN ((int32_t) in_prv.height - ((int32_t) (H_idx * stride_height)
+                                - padding_top + w.kernel_height), 0);
 
-                        int32_t rows = kernel_height - top_comp - bottom_comp;
-                        int32_t clmns = kernel_width - right_comp - left_comp;
+                        int32_t rows = w.kernel_height - top_comp - bottom_comp;
+                        int32_t clmns = w.kernel_width - right_comp - left_comp;
 
-                        int8_t *in_ptr = in_ftrs +  // starting point
-                                in_ch * in_width * (H_idx * stride_height - padding_top + top_comp) +   // move to row
-                                in_ch * ((W_idx * stride_width) - padding_left + left_comp);    // move to column
+                        const MLI_PTR (int8_t) in_ptr = in_prv.ptr                                          // starting point
+                                + in_prv.col_mem_stride * (W_idx * stride_width - padding_left + left_comp) // move to column
+                                + in_prv.row_mem_stride * (H_idx * stride_height - padding_top + top_comp); // move to row
 
-                        int8_t *w_ptr = wt +    // Start point
-                                out_ch_idx * in_ch * kernel_width * kernel_height + // move to filter
-                                top_comp * kernel_width * in_ch +   // move to row
-                                left_comp * in_ch;  // move to column
+                        const MLI_PTR (int8_t) w_ptr = w.ptr        // Start point
+                                + w.col_mem_stride * left_comp      // move to column
+                                + w.row_mem_stride * top_comp       // move to row
+                                + w.out_ch_mem_stride * out_ch_idx; // move to filter
 
                         // Convolution core
-                        conv_out += dotprod2D (in_ptr, w_ptr, clmns * in_ch, rows, in_width * in_ch, kernel_width * in_ch);
+                        for (int in_ch_idx = 0; in_ch_idx < in_prv.ch - 1; in_ch_idx += 2) {
+                            dotprod2D_hwc_d (in_ptr, w_ptr, &accu, clmns, rows,
+                                    in_prv.col_mem_stride, in_prv.row_mem_stride,
+                                    w.col_mem_stride, w.row_mem_stride);
+                            in_ptr += 2;
+                            w_ptr += 2;
+                        }
 
-                        MLI_CONV_OUT_PTR(int8_t) o_ptr = &out_ftrs[out_ch_idx + (H_idx * out_width + W_idx) * out_ch];
-                        mli_prv_clip_relu_store_output (o_ptr, conv_out, out_shift, val_limit.min, val_limit.max);
+                        if (in_prv.ch & 1) {
+                            accu = dotprod2D( in_ptr, w_ptr, accu, clmns, rows,
+                                    in_prv.col_mem_stride, in_prv.row_mem_stride,
+                                    w.col_mem_stride, w.row_mem_stride);
+                            in_ptr += 1;
+                            w_ptr += 1;
+                        }
+                        in_ptr -= in_prv.ch;
+                        w_ptr -= in_prv.ch;
+
+                        MLI_CONV_OUT_PTR(int8_t) o_ptr = out_prv.ptr
+                                + out_prv.col_mem_stride * W_idx
+                                + out_prv.row_mem_stride * H_idx
+                                + out_prv.ch_mem_stride * out_ch_idx;
+                        mli_prv_clip_relu_store_output (o_ptr, accu, out_shift, val_limit.min, val_limit.max);
                     }
                 }
             }
         }
     }
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[0] = out_height;
-    out->shape[1] = out_width;
-    out->shape[2] = out_ch;
 
     return MLI_STATUS_OK;
-}
-
-static inline int32_t dotprod2D (
-        int8_t * in, 
-        int8_t * krn, 
-        uint32_t width, 
-        uint32_t height, 
-        uint32_t in_row_step, 
-        uint32_t kern_row_step) {
-    int32_t accu = 0;
-    in_row_step -= width;
-    kern_row_step -= width;
-    for (uint32_t row = 0; row < height; row++) {
-        for (uint32_t clmn = 0; clmn < width; clmn++) {
-            accu += (*in++) * (*krn++);
-        }
-        in += in_row_step;
-        krn += kern_row_step;
-    }
-    return accu;
 }
 
 #pragma code()

--- a/lib/src/kernels/convolution/mli_krn_conv2d_hwc_fx8w16d.cc
+++ b/lib/src/kernels/convolution/mli_krn_conv2d_hwc_fx8w16d.cc
@@ -17,16 +17,6 @@
 #include "mli_prv_dsp.h"
 #include "mli_krn_dotprod.h"
 
- /**
- * Function Short Description
- *
- * \param[in]
- * \param[in/out]
- * \param[out]
- * \result
- *
- * Some Details
- */
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,62 +46,68 @@ mli_status mli_krn_conv2d_hwc_fx8w16d (
     out->el_type = MLI_EL_FX_16;
     // Define output val limits - we need it in case built-in RELU
     val_limit = mli_prv_get_relu_min_max (&cfg->relu, out);
-
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t))in->data;
-    MLI_CONV_OUT_PTR(int16_t) out_ftrs = (MLI_CONV_OUT_PTR(int16_t))out->data;
-    MLI_PTR(int8_t) wt = (MLI_PTR(int8_t))weights->data;
     MLI_PTR(int8_t) bs = (MLI_PTR(int8_t))bias->data;
 
-    uint16_t in_ch = in->shape[2];
-    uint16_t out_ch = weights->shape[0];
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in);
+    const auto w = mli_prv_get_conv2d_weights_tensor_nhwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(weights);
+    __builtin_assume(in_prv.ch == w.in_ch);
 
-    uint16_t kernel_height = weights->shape[1];
-    uint16_t kernel_width = weights->shape[2];
+    uint16_t out_width = CEIL_DIV (in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    uint16_t out_height = CEIL_DIV (in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-    uint16_t in_height = in->shape[0];
-    uint16_t in_width = in->shape[1];
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[0] = out_height;
+    out->shape[1] = out_width;
+    out->shape[2] = w.out_ch;
 
-    uint16_t out_width = (in_width + padding_left + padding_right - kernel_width + 1);
-    out_width = (out_width % stride_width != 0) ? (out_width / stride_width + 1) : out_width / stride_width;
-
-    uint16_t out_height = (in_height + padding_top + padding_bot - kernel_height + 1);
-    out_height = (out_height % stride_height != 0) ? (out_height / stride_height + 1) : out_height / stride_height;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int16_t), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     uint8_t bias_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits) - bias->el_params.fx.frac_bits;
     uint8_t out_shift = (in->el_params.fx.frac_bits + weights->el_params.fx.frac_bits) - out->el_params.fx.frac_bits;
 
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
-    if (in_height >= kernel_height && in_width >= kernel_width) {
+    if (in_prv.height >= w.kernel_height && in_prv.width >= w.kernel_width) {
         rect_t cent_area;
-        cent_area.row_beg = (padding_top % stride_height != 0) ? (padding_top / stride_height + 1) 
-                : padding_top / stride_height;
-        cent_area.row_end = out_height - ((padding_bot % stride_height != 0) ? (padding_bot / stride_height + 1) 
-                : padding_bot / stride_height);
-        cent_area.clmn_beg = (padding_left % stride_width != 0) ? (padding_left / stride_width + 1) 
-                : padding_left / stride_width;
-        cent_area.clmn_end = out_width - ((padding_right % stride_width != 0) ? (padding_right / stride_width + 1) 
-                : padding_right / stride_width);
-        for (uint32_t out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
+        cent_area.row_beg = CEIL_DIV (padding_top, stride_height);
+        cent_area.row_end = out_height - CEIL_DIV (padding_bot, stride_height);
+        cent_area.clmn_beg = CEIL_DIV (padding_left, stride_width);
+        cent_area.clmn_end = out_width - CEIL_DIV (padding_right, stride_width);
+
+        for (uint32_t out_ch_idx = 0; out_ch_idx < w.out_ch; out_ch_idx++) {
             for (uint32_t H_idx = cent_area.row_beg; H_idx < cent_area.row_end; H_idx++) {
                 for (uint32_t W_idx = cent_area.clmn_beg; W_idx < cent_area.clmn_end; W_idx++) {
-                    auto conv_out = mli_prv_init_accu_with_bias (in_ftrs, bs[out_ch_idx], bias_shift);
+                    auto accu = mli_prv_init_accu_with_bias (in_prv.ptr, bs[out_ch_idx], bias_shift);
 
                     // Define area of input and filter for convolution
+                    const MLI_PTR (int16_t) in_ptr = in_prv.ptr +
+                            + in_prv.row_mem_stride * (H_idx * stride_height - padding_top)  // move to row
+                            + in_prv.col_mem_stride * (W_idx * stride_width - padding_left); // move to column
 
-                    MLI_PTR(int16_t) in_ptr = in_ftrs + // starting point
-                            in_ch * in_width * (H_idx * stride_height - padding_top) +  // move to row
-                            in_ch * (W_idx * stride_width - padding_left);  // move to column
-
-                    MLI_PTR(int8_t) w_ptr = wt +    // Start point
-                            out_ch_idx * in_ch * kernel_width * kernel_height;  // move to filter
+                    const MLI_PTR(int8_t) w_ptr = w.ptr
+                            + w.out_ch_mem_stride * out_ch_idx; // move to filter
 
                     // Convolution core
-                    dotprod2D (in_ptr, w_ptr, kernel_width * in_ch, kernel_height, in_width * in_ch, 
-                            kernel_width * in_ch, &conv_out);
+                    for (int in_ch_idx = 0; in_ch_idx < in_prv.ch - 1; in_ch_idx += 2) {
+                        dotprod2D_hwc_d (in_ptr, w_ptr, &accu, w.kernel_width, w.kernel_height,
+                                in_prv.col_mem_stride, in_prv.row_mem_stride,
+                                w.col_mem_stride, w.row_mem_stride);
+                        in_ptr += 2;
+                        w_ptr += 2;
+                    }
 
-                    MLI_CONV_OUT_PTR(int16_t) o_ptr = &out_ftrs[out_ch_idx + (H_idx * out_width + W_idx) * out_ch];
-                    mli_prv_clip_relu_store_output (o_ptr, conv_out, out_shift, val_limit.min, val_limit.max);
+                    if (in_prv.ch & 1) {
+                        accu = dotprod2D (in_ptr, w_ptr, accu, w.kernel_width, w.kernel_height,
+                                in_prv.col_mem_stride, in_prv.row_mem_stride,
+                                w.col_mem_stride, w.row_mem_stride);
+                        in_ptr += 1;
+                        w_ptr += 1;
+                    }
+                    MLI_CONV_OUT_PTR(int16_t) o_ptr = &out_prv.ptr[out_ch_idx +
+                        (out_prv.row_mem_stride * H_idx) +
+                        (out_prv.col_mem_stride * W_idx)];
+                    mli_prv_clip_relu_store_output (o_ptr, accu, out_shift, val_limit.min, val_limit.max);
                 }
             }
         }
@@ -148,48 +144,62 @@ mli_status mli_krn_conv2d_hwc_fx8w16d (
         }
 
         for (uint32_t area_idx = 0; area_idx < areas_num; ++area_idx) {
-            for (uint32_t out_ch_idx = 0; out_ch_idx < out_ch; out_ch_idx++) {
+            for (uint32_t out_ch_idx = 0; out_ch_idx < w.out_ch; out_ch_idx++) {
                 for (uint32_t H_idx = perc_areas[area_idx].row_beg; H_idx < perc_areas[area_idx].row_end; H_idx++) {
                     for (uint32_t W_idx = perc_areas[area_idx].clmn_beg; W_idx < perc_areas[area_idx].clmn_end; W_idx++) {
-                        auto conv_out = mli_prv_init_accu_with_bias (in_ftrs, bs[out_ch_idx], bias_shift);
+                        auto accu = mli_prv_init_accu_with_bias (in_prv.ptr, bs[out_ch_idx], bias_shift);
 
                         // Define area of input and filter for convolution
                         // *_comp - compensation values for valid area defining
                         int32_t top_comp = -MIN ((int32_t) (H_idx * stride_height) - padding_top, 0);
                         int32_t left_comp = -MIN ((int32_t) (W_idx * stride_width) - padding_left, 0);
 
-                        int32_t right_comp = -MIN ((int32_t) in_width - ((int32_t) (W_idx * stride_width) 
-                                - padding_left + kernel_width), 0);
-                        int32_t bottom_comp = -MIN ((int32_t) in_height - ((int32_t) (H_idx * stride_height) 
-                                - padding_top + kernel_height), 0);
+                        int32_t right_comp = -MIN ((int32_t) in_prv.width - ((int32_t) (W_idx * stride_width)
+                                - padding_left + w.kernel_width), 0);
+                        int32_t bottom_comp = -MIN ((int32_t) in_prv.height - ((int32_t) (H_idx * stride_height)
+                                - padding_top + w.kernel_height), 0);
 
-                        int32_t rows = kernel_height - top_comp - bottom_comp;
-                        int32_t clmns = kernel_width - right_comp - left_comp;
+                        int32_t rows = w.kernel_height - top_comp - bottom_comp;
+                        int32_t clmns = w.kernel_width - right_comp - left_comp;
 
-                        MLI_PTR(int16_t) in_ptr = in_ftrs + // starting point
-                                in_ch * in_width * (H_idx * stride_height - padding_top + top_comp) +   // move to row
-                                in_ch * ((W_idx * stride_width) - padding_left + left_comp);    // move to column
+                        const MLI_PTR (int16_t) in_ptr = in_prv.ptr
+                                + in_prv.col_mem_stride * (W_idx * stride_width - padding_left + left_comp) // move to column
+                                + in_prv.row_mem_stride * (H_idx * stride_height - padding_top + top_comp); // move to row
 
-                        MLI_PTR(int8_t) w_ptr = wt +    // Start point
-                                out_ch_idx * in_ch * kernel_width * kernel_height + // move to filter
-                                top_comp * kernel_width * in_ch +   // move to row
-                                left_comp * in_ch;  // move to column
+                        const MLI_PTR (int8_t) w_ptr = w.ptr
+                                + w.col_mem_stride * left_comp      // move to column
+                                + w.row_mem_stride * top_comp       // move to row
+                                + w.out_ch_mem_stride * out_ch_idx; // move to filter
 
                         // Convolution core
-                        dotprod2D (in_ptr, w_ptr, clmns * in_ch, rows, in_width * in_ch, kernel_width * in_ch, &conv_out);
+                        for (int in_ch_idx = 0; in_ch_idx < in_prv.ch - 1; in_ch_idx += 2) {
+                            dotprod2D_hwc_d (in_ptr, w_ptr, &accu, clmns, rows,
+                                    in_prv.col_mem_stride, in_prv.row_mem_stride,
+                                    w.col_mem_stride, w.row_mem_stride);
+                            in_ptr += 2;
+                            w_ptr += 2;
+                        }
 
-                        MLI_CONV_OUT_PTR(int16_t) o_ptr = &out_ftrs[out_ch_idx + (H_idx * out_width + W_idx) * out_ch];
-                        mli_prv_clip_relu_store_output (o_ptr, conv_out, out_shift, val_limit.min, val_limit.max);
+                        if (in_prv.ch & 1) {
+                            accu = dotprod2D( in_ptr, w_ptr, accu, clmns, rows,
+                                    in_prv.col_mem_stride, in_prv.row_mem_stride,
+                                    w.col_mem_stride, w.row_mem_stride);
+                            in_ptr += 1;
+                            w_ptr += 1;
+                        }
+                        in_ptr -= in_prv.ch;
+                        w_ptr -= in_prv.ch;
+
+                        MLI_CONV_OUT_PTR(int16_t) o_ptr = out_prv.ptr
+                                + out_prv.col_mem_stride * W_idx
+                                + out_prv.row_mem_stride * H_idx
+                                + out_prv.ch_mem_stride * out_ch_idx;
+                        mli_prv_clip_relu_store_output (o_ptr, accu, out_shift, val_limit.min, val_limit.max);
                     }
                 }
             }
         }
     }
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[0] = out_height;
-    out->shape[1] = out_width;
-    out->shape[2] = out_ch;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/convolution/mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32.cc
+++ b/lib/src/kernels/convolution/mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32.cc
@@ -48,10 +48,14 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k3x3_krnpad(
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int kernel_height = weights->shape[KRNL_DW_H_DIM_HWC];
-    int kernel_width = weights->shape[KRNL_DW_W_DIM_HWC];
-    int out_ch = weights->shape[KRNL_DW_C_DIM_HWC];
-    int in_ch = in->shape[FMAP_C_DIM_HWC];
+
+    // Define Data dimensions
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+    const auto w = mli_prv_get_conv2d_weights_tensor_1hwn<MLI_PTR(int8_t), MLI_PTR_IS_XY>(
+            weights,
+            3,  // kernel_width
+            3); // kernel_height
 
     // assign hard coded values for this variation to some variables
 #if 0
@@ -66,15 +70,6 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k3x3_krnpad(
     MLI_CHECK_AND_FIX(padding_left, 0);
     MLI_CHECK_AND_FIX(padding_right, 0);
 #endif
-#if 3
-    MLI_CHECK_AND_FIX(kernel_width, 3);
-#endif
-#if 3
-    MLI_CHECK_AND_FIX(kernel_height, 3);
-#endif
-#if 0
-    MLI_CHECK_AND_FIX(in_ch, 0);
-#endif
 
     mli_minmax_t val_limit;
     // fill output tensor el_type parameter
@@ -83,18 +78,18 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k3x3_krnpad(
     val_limit = mli_prv_get_relu_min_max(&cfg->relu, out);
 
     // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_CONV_OUT_PTR(int8_t) out_ftrs = (MLI_CONV_OUT_PTR(int8_t ))out->data;
-    MLI_PTR(int8_t) wt = (MLI_PTR(int8_t ))weights->data;
     MLI_PTR(int32_t) bs = (MLI_PTR(int32_t ))bias->data;
 
      // Define Data dimensions
-    int in_height = in->shape[FMAP_H_DIM_HWC];
-    int in_width = in->shape[FMAP_W_DIM_HWC];
+    int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-
-    int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_HWC] = w.out_ch;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int8_t), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     // Define quantization specific params
     s8asym_quant_specific_params params;
@@ -108,16 +103,9 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k3x3_krnpad(
     cent_area.clmn_end = out_width;
 
     depthwise_convolution2D_hwcn_krnpad<int8_t, int8_t, int32_t, int32_t>(
-            in_ftrs, wt, bs, out_ftrs, &cent_area, params,
-            (int8_t)val_limit.min, (int8_t)val_limit.max, in_ch, in_width, in_height, 
-            out_ch, out_width, out_height, kernel_height, kernel_width,
+            in_prv, w, bs, out_prv, &cent_area, params,
+            (int8_t)val_limit.min, (int8_t)val_limit.max,
             stride_height, stride_width, padding_top, padding_left, padding_bot, padding_right);
-
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_HWC] = out_ch;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
 
     return MLI_STATUS_OK;
 }
@@ -141,10 +129,14 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k5x5_krnpad(
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int kernel_height = weights->shape[KRNL_DW_H_DIM_HWC];
-    int kernel_width = weights->shape[KRNL_DW_W_DIM_HWC];
-    int out_ch = weights->shape[KRNL_DW_C_DIM_HWC];
-    int in_ch = in->shape[FMAP_C_DIM_HWC];
+
+    // Define Data dimensions
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+    const auto w = mli_prv_get_conv2d_weights_tensor_1hwn<MLI_PTR(int8_t), MLI_PTR_IS_XY>(
+            weights,
+            5,  // kernel_width
+            5); // kernel_height
 
     // assign hard coded values for this variation to some variables
 #if 0
@@ -159,15 +151,6 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k5x5_krnpad(
     MLI_CHECK_AND_FIX(padding_left, 0);
     MLI_CHECK_AND_FIX(padding_right, 0);
 #endif
-#if 5
-    MLI_CHECK_AND_FIX(kernel_width, 5);
-#endif
-#if 5
-    MLI_CHECK_AND_FIX(kernel_height, 5);
-#endif
-#if 0
-    MLI_CHECK_AND_FIX(in_ch, 0);
-#endif
 
     mli_minmax_t val_limit;
     // fill output tensor el_type parameter
@@ -176,18 +159,18 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k5x5_krnpad(
     val_limit = mli_prv_get_relu_min_max(&cfg->relu, out);
 
     // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_CONV_OUT_PTR(int8_t) out_ftrs = (MLI_CONV_OUT_PTR(int8_t ))out->data;
-    MLI_PTR(int8_t) wt = (MLI_PTR(int8_t ))weights->data;
     MLI_PTR(int32_t) bs = (MLI_PTR(int32_t ))bias->data;
 
      // Define Data dimensions
-    int in_height = in->shape[FMAP_H_DIM_HWC];
-    int in_width = in->shape[FMAP_W_DIM_HWC];
+    int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-
-    int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_HWC] = w.out_ch;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int8_t), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     // Define quantization specific params
     s8asym_quant_specific_params params;
@@ -201,16 +184,9 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k5x5_krnpad(
     cent_area.clmn_end = out_width;
 
     depthwise_convolution2D_hwcn_krnpad<int8_t, int8_t, int32_t, int32_t>(
-            in_ftrs, wt, bs, out_ftrs, &cent_area, params,
-            (int8_t)val_limit.min, (int8_t)val_limit.max, in_ch, in_width, in_height, 
-            out_ch, out_width, out_height, kernel_height, kernel_width,
+            in_prv, w, bs, out_prv, &cent_area, params,
+            (int8_t)val_limit.min, (int8_t)val_limit.max,
             stride_height, stride_width, padding_top, padding_left, padding_bot, padding_right);
-
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_HWC] = out_ch;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
 
     return MLI_STATUS_OK;
 }
@@ -234,10 +210,14 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k3x3_nopad(
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int kernel_height = weights->shape[KRNL_DW_H_DIM_HWC];
-    int kernel_width = weights->shape[KRNL_DW_W_DIM_HWC];
-    int out_ch = weights->shape[KRNL_DW_C_DIM_HWC];
-    int in_ch = in->shape[FMAP_C_DIM_HWC];
+
+    // Define Data dimensions
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+    const auto w = mli_prv_get_conv2d_weights_tensor_1hwn<MLI_PTR(int8_t), MLI_PTR_IS_XY>(
+            weights,
+            3,  // kernel_width
+            3); // kernel_height
 
     // assign hard coded values for this variation to some variables
 #if 0
@@ -252,15 +232,6 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k3x3_nopad(
     MLI_CHECK_AND_FIX(padding_left, 0);
     MLI_CHECK_AND_FIX(padding_right, 0);
 #endif
-#if 3
-    MLI_CHECK_AND_FIX(kernel_width, 3);
-#endif
-#if 3
-    MLI_CHECK_AND_FIX(kernel_height, 3);
-#endif
-#if 0
-    MLI_CHECK_AND_FIX(in_ch, 0);
-#endif
 
     mli_minmax_t val_limit;
     // fill output tensor el_type parameter
@@ -269,18 +240,18 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k3x3_nopad(
     val_limit = mli_prv_get_relu_min_max(&cfg->relu, out);
 
     // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_CONV_OUT_PTR(int8_t) out_ftrs = (MLI_CONV_OUT_PTR(int8_t ))out->data;
-    MLI_PTR(int8_t) wt = (MLI_PTR(int8_t ))weights->data;
     MLI_PTR(int32_t) bs = (MLI_PTR(int32_t ))bias->data;
 
      // Define Data dimensions
-    int in_height = in->shape[FMAP_H_DIM_HWC];
-    int in_width = in->shape[FMAP_W_DIM_HWC];
+    int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-
-    int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_HWC] = w.out_ch;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int8_t), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     // Define quantization specific params
     s8asym_quant_specific_params params;
@@ -294,16 +265,9 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k3x3_nopad(
     cent_area.clmn_end = out_width;
 
     depthwise_convolution2D_hwcn_nopad<int8_t, int8_t, int32_t, int32_t>(
-            in_ftrs, wt, bs, out_ftrs, &cent_area, params,
-            (int8_t)val_limit.min, (int8_t)val_limit.max, in_ch, in_width, in_height, 
-            out_ch, out_width, out_height, kernel_height, kernel_width,
+            in_prv, w, bs, out_prv, &cent_area, params,
+            (int8_t)val_limit.min, (int8_t)val_limit.max,
             stride_height, stride_width, padding_top, padding_left, padding_bot, padding_right);
-
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_HWC] = out_ch;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
 
     return MLI_STATUS_OK;
 }
@@ -327,10 +291,14 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k5x5_nopad(
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int kernel_height = weights->shape[KRNL_DW_H_DIM_HWC];
-    int kernel_width = weights->shape[KRNL_DW_W_DIM_HWC];
-    int out_ch = weights->shape[KRNL_DW_C_DIM_HWC];
-    int in_ch = in->shape[FMAP_C_DIM_HWC];
+
+    // Define Data dimensions
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+    const auto w = mli_prv_get_conv2d_weights_tensor_1hwn<MLI_PTR(int8_t), MLI_PTR_IS_XY>(
+            weights,
+            5,  // kernel_width
+            5); // kernel_height
 
     // assign hard coded values for this variation to some variables
 #if 0
@@ -345,15 +313,6 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k5x5_nopad(
     MLI_CHECK_AND_FIX(padding_left, 0);
     MLI_CHECK_AND_FIX(padding_right, 0);
 #endif
-#if 5
-    MLI_CHECK_AND_FIX(kernel_width, 5);
-#endif
-#if 5
-    MLI_CHECK_AND_FIX(kernel_height, 5);
-#endif
-#if 0
-    MLI_CHECK_AND_FIX(in_ch, 0);
-#endif
 
     mli_minmax_t val_limit;
     // fill output tensor el_type parameter
@@ -362,18 +321,18 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k5x5_nopad(
     val_limit = mli_prv_get_relu_min_max(&cfg->relu, out);
 
     // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_CONV_OUT_PTR(int8_t) out_ftrs = (MLI_CONV_OUT_PTR(int8_t ))out->data;
-    MLI_PTR(int8_t) wt = (MLI_PTR(int8_t ))weights->data;
     MLI_PTR(int32_t) bs = (MLI_PTR(int32_t ))bias->data;
 
      // Define Data dimensions
-    int in_height = in->shape[FMAP_H_DIM_HWC];
-    int in_width = in->shape[FMAP_W_DIM_HWC];
+    int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-
-    int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_HWC] = w.out_ch;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int8_t), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     // Define quantization specific params
     s8asym_quant_specific_params params;
@@ -387,16 +346,9 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_k5x5_nopad(
     cent_area.clmn_end = out_width;
 
     depthwise_convolution2D_hwcn_nopad<int8_t, int8_t, int32_t, int32_t>(
-            in_ftrs, wt, bs, out_ftrs, &cent_area, params,
-            (int8_t)val_limit.min, (int8_t)val_limit.max, in_ch, in_width, in_height, 
-            out_ch, out_width, out_height, kernel_height, kernel_width,
+            in_prv, w, bs, out_prv, &cent_area, params,
+            (int8_t)val_limit.min, (int8_t)val_limit.max,
             stride_height, stride_width, padding_top, padding_left, padding_bot, padding_right);
-
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_HWC] = out_ch;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
 
     return MLI_STATUS_OK;
 }
@@ -420,10 +372,14 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_generic(
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int kernel_height = weights->shape[KRNL_DW_H_DIM_HWC];
-    int kernel_width = weights->shape[KRNL_DW_W_DIM_HWC];
-    int out_ch = weights->shape[KRNL_DW_C_DIM_HWC];
-    int in_ch = in->shape[FMAP_C_DIM_HWC];
+
+    // Define Data dimensions
+    const auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+    const auto w = mli_prv_get_conv2d_weights_tensor_1hwn<MLI_PTR(int8_t), MLI_PTR_IS_XY>(
+            weights,
+            0,  // kernel_width
+            0); // kernel_height
 
     // assign hard coded values for this variation to some variables
 #if 0
@@ -438,15 +394,6 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_generic(
     MLI_CHECK_AND_FIX(padding_left, 0);
     MLI_CHECK_AND_FIX(padding_right, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(kernel_width, 0);
-#endif
-#if 0
-    MLI_CHECK_AND_FIX(kernel_height, 0);
-#endif
-#if 0
-    MLI_CHECK_AND_FIX(in_ch, 0);
-#endif
 
     mli_minmax_t val_limit;
     // fill output tensor el_type parameter
@@ -455,18 +402,18 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_generic(
     val_limit = mli_prv_get_relu_min_max(&cfg->relu, out);
 
     // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_CONV_OUT_PTR(int8_t) out_ftrs = (MLI_CONV_OUT_PTR(int8_t ))out->data;
-    MLI_PTR(int8_t) wt = (MLI_PTR(int8_t ))weights->data;
     MLI_PTR(int32_t) bs = (MLI_PTR(int32_t ))bias->data;
 
      // Define Data dimensions
-    int in_height = in->shape[FMAP_H_DIM_HWC];
-    int in_width = in->shape[FMAP_W_DIM_HWC];
+    int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - w.kernel_width + 1, stride_width);
+    int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - w.kernel_height + 1, stride_height);
 
-
-    int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_HWC] = w.out_ch;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_CONV_OUT_PTR(int8_t), MLI_CONV_OUT_PTR_IS_XY>(out);
 
     // Define quantization specific params
     s8asym_quant_specific_params params;
@@ -480,16 +427,9 @@ mli_status mli_krn_depthwise_conv2d_hwcn_sa8_sa8_sa32_generic(
     cent_area.clmn_end = out_width;
 
     depthwise_convolution2D_hwcn_krnpad<int8_t, int8_t, int32_t, int32_t>(
-            in_ftrs, wt, bs, out_ftrs, &cent_area, params,
-            (int8_t)val_limit.min, (int8_t)val_limit.max, in_ch, in_width, in_height, 
-            out_ch, out_width, out_height, kernel_height, kernel_width,
+            in_prv, w, bs, out_prv, &cent_area, params,
+            (int8_t)val_limit.min, (int8_t)val_limit.max,
             stride_height, stride_width, padding_top, padding_left, padding_bot, padding_right);
-
-    // fill output tensor parameters
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_HWC] = out_ch;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_avepool_chw_fx16.cc
+++ b/lib/src/kernels/pooling/mli_krn_avepool_chw_fx16.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_avepool_chw_fx16_k2x2_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -63,20 +67,19 @@ mli_status mli_krn_avepool_chw_fx16_k2x2_krnpad(const mli_tensor * in, const mli
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -88,20 +91,10 @@ mli_status mli_krn_avepool_chw_fx16_k2x2_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -118,9 +111,13 @@ mli_status mli_krn_avepool_chw_fx16_k3x3_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -140,20 +137,19 @@ mli_status mli_krn_avepool_chw_fx16_k3x3_krnpad(const mli_tensor * in, const mli
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -165,20 +161,10 @@ mli_status mli_krn_avepool_chw_fx16_k3x3_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -195,9 +181,13 @@ mli_status mli_krn_avepool_chw_fx16_k4x4_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -217,20 +207,19 @@ mli_status mli_krn_avepool_chw_fx16_k4x4_krnpad(const mli_tensor * in, const mli
 #if 4
     MLI_CHECK_AND_FIX(kernel_height, 4);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -242,20 +231,10 @@ mli_status mli_krn_avepool_chw_fx16_k4x4_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -272,9 +251,13 @@ mli_status mli_krn_avepool_chw_fx16_k5x5_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -294,20 +277,19 @@ mli_status mli_krn_avepool_chw_fx16_k5x5_krnpad(const mli_tensor * in, const mli
 #if 5
     MLI_CHECK_AND_FIX(kernel_height, 5);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -319,20 +301,10 @@ mli_status mli_krn_avepool_chw_fx16_k5x5_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -349,9 +321,13 @@ mli_status mli_krn_avepool_chw_fx16_k6x6_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -371,20 +347,19 @@ mli_status mli_krn_avepool_chw_fx16_k6x6_krnpad(const mli_tensor * in, const mli
 #if 6
     MLI_CHECK_AND_FIX(kernel_height, 6);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -396,20 +371,10 @@ mli_status mli_krn_avepool_chw_fx16_k6x6_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -426,9 +391,13 @@ mli_status mli_krn_avepool_chw_fx16_k7x7_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -448,20 +417,19 @@ mli_status mli_krn_avepool_chw_fx16_k7x7_krnpad(const mli_tensor * in, const mli
 #if 7
     MLI_CHECK_AND_FIX(kernel_height, 7);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -473,20 +441,10 @@ mli_status mli_krn_avepool_chw_fx16_k7x7_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -503,9 +461,13 @@ mli_status mli_krn_avepool_chw_fx16_k8x8_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -525,20 +487,19 @@ mli_status mli_krn_avepool_chw_fx16_k8x8_krnpad(const mli_tensor * in, const mli
 #if 8
     MLI_CHECK_AND_FIX(kernel_height, 8);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -550,20 +511,10 @@ mli_status mli_krn_avepool_chw_fx16_k8x8_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -580,9 +531,13 @@ mli_status mli_krn_avepool_chw_fx16_k9x9_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -602,20 +557,19 @@ mli_status mli_krn_avepool_chw_fx16_k9x9_krnpad(const mli_tensor * in, const mli
 #if 9
     MLI_CHECK_AND_FIX(kernel_height, 9);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -627,20 +581,10 @@ mli_status mli_krn_avepool_chw_fx16_k9x9_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -657,9 +601,13 @@ mli_status mli_krn_avepool_chw_fx16_k10x10_krnpad(const mli_tensor * in, const m
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -679,20 +627,19 @@ mli_status mli_krn_avepool_chw_fx16_k10x10_krnpad(const mli_tensor * in, const m
 #if 10
     MLI_CHECK_AND_FIX(kernel_height, 10);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -704,20 +651,10 @@ mli_status mli_krn_avepool_chw_fx16_k10x10_krnpad(const mli_tensor * in, const m
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -734,9 +671,13 @@ mli_status mli_krn_avepool_chw_fx16_k2x2_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -756,20 +697,19 @@ mli_status mli_krn_avepool_chw_fx16_k2x2_nopad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -781,20 +721,10 @@ mli_status mli_krn_avepool_chw_fx16_k2x2_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -811,9 +741,13 @@ mli_status mli_krn_avepool_chw_fx16_k3x3_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -833,20 +767,19 @@ mli_status mli_krn_avepool_chw_fx16_k3x3_nopad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -858,20 +791,10 @@ mli_status mli_krn_avepool_chw_fx16_k3x3_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -888,9 +811,13 @@ mli_status mli_krn_avepool_chw_fx16_k4x4_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -910,20 +837,19 @@ mli_status mli_krn_avepool_chw_fx16_k4x4_nopad(const mli_tensor * in, const mli_
 #if 4
     MLI_CHECK_AND_FIX(kernel_height, 4);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -935,20 +861,10 @@ mli_status mli_krn_avepool_chw_fx16_k4x4_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -965,9 +881,13 @@ mli_status mli_krn_avepool_chw_fx16_k5x5_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -987,20 +907,19 @@ mli_status mli_krn_avepool_chw_fx16_k5x5_nopad(const mli_tensor * in, const mli_
 #if 5
     MLI_CHECK_AND_FIX(kernel_height, 5);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1012,20 +931,10 @@ mli_status mli_krn_avepool_chw_fx16_k5x5_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1042,9 +951,13 @@ mli_status mli_krn_avepool_chw_fx16_k6x6_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1064,20 +977,19 @@ mli_status mli_krn_avepool_chw_fx16_k6x6_nopad(const mli_tensor * in, const mli_
 #if 6
     MLI_CHECK_AND_FIX(kernel_height, 6);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1089,20 +1001,10 @@ mli_status mli_krn_avepool_chw_fx16_k6x6_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1119,9 +1021,13 @@ mli_status mli_krn_avepool_chw_fx16_k7x7_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1141,20 +1047,19 @@ mli_status mli_krn_avepool_chw_fx16_k7x7_nopad(const mli_tensor * in, const mli_
 #if 7
     MLI_CHECK_AND_FIX(kernel_height, 7);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1166,20 +1071,10 @@ mli_status mli_krn_avepool_chw_fx16_k7x7_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1196,9 +1091,13 @@ mli_status mli_krn_avepool_chw_fx16_k8x8_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1218,20 +1117,19 @@ mli_status mli_krn_avepool_chw_fx16_k8x8_nopad(const mli_tensor * in, const mli_
 #if 8
     MLI_CHECK_AND_FIX(kernel_height, 8);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1243,20 +1141,10 @@ mli_status mli_krn_avepool_chw_fx16_k8x8_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1273,9 +1161,13 @@ mli_status mli_krn_avepool_chw_fx16_k9x9_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1295,20 +1187,19 @@ mli_status mli_krn_avepool_chw_fx16_k9x9_nopad(const mli_tensor * in, const mli_
 #if 9
     MLI_CHECK_AND_FIX(kernel_height, 9);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1320,20 +1211,10 @@ mli_status mli_krn_avepool_chw_fx16_k9x9_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1350,9 +1231,13 @@ mli_status mli_krn_avepool_chw_fx16_k10x10_nopad(const mli_tensor * in, const ml
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1372,20 +1257,19 @@ mli_status mli_krn_avepool_chw_fx16_k10x10_nopad(const mli_tensor * in, const ml
 #if 10
     MLI_CHECK_AND_FIX(kernel_height, 10);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1397,20 +1281,10 @@ mli_status mli_krn_avepool_chw_fx16_k10x10_nopad(const mli_tensor * in, const ml
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1427,9 +1301,13 @@ mli_status mli_krn_avepool_chw_fx16_k1xn_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1449,20 +1327,19 @@ mli_status mli_krn_avepool_chw_fx16_k1xn_krnpad(const mli_tensor * in, const mli
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1474,20 +1351,10 @@ mli_status mli_krn_avepool_chw_fx16_k1xn_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1504,9 +1371,13 @@ mli_status mli_krn_avepool_chw_fx16_k1x2_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1526,20 +1397,19 @@ mli_status mli_krn_avepool_chw_fx16_k1x2_krnpad(const mli_tensor * in, const mli
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1551,20 +1421,10 @@ mli_status mli_krn_avepool_chw_fx16_k1x2_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1581,9 +1441,13 @@ mli_status mli_krn_avepool_chw_fx16_k1x3_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1603,20 +1467,19 @@ mli_status mli_krn_avepool_chw_fx16_k1x3_krnpad(const mli_tensor * in, const mli
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1628,20 +1491,10 @@ mli_status mli_krn_avepool_chw_fx16_k1x3_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1658,9 +1511,13 @@ mli_status mli_krn_avepool_chw_fx16_knx1_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1680,20 +1537,19 @@ mli_status mli_krn_avepool_chw_fx16_knx1_krnpad(const mli_tensor * in, const mli
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1705,20 +1561,10 @@ mli_status mli_krn_avepool_chw_fx16_knx1_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1735,9 +1581,13 @@ mli_status mli_krn_avepool_chw_fx16_k2x1_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1757,20 +1607,19 @@ mli_status mli_krn_avepool_chw_fx16_k2x1_krnpad(const mli_tensor * in, const mli
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1782,20 +1631,10 @@ mli_status mli_krn_avepool_chw_fx16_k2x1_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1812,9 +1651,13 @@ mli_status mli_krn_avepool_chw_fx16_k3x1_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1834,20 +1677,19 @@ mli_status mli_krn_avepool_chw_fx16_k3x1_krnpad(const mli_tensor * in, const mli
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1859,20 +1701,10 @@ mli_status mli_krn_avepool_chw_fx16_k3x1_krnpad(const mli_tensor * in, const mli
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1889,9 +1721,13 @@ mli_status mli_krn_avepool_chw_fx16_k1xn_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1911,20 +1747,19 @@ mli_status mli_krn_avepool_chw_fx16_k1xn_nopad(const mli_tensor * in, const mli_
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1936,20 +1771,10 @@ mli_status mli_krn_avepool_chw_fx16_k1xn_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1966,9 +1791,13 @@ mli_status mli_krn_avepool_chw_fx16_k1x2_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1988,20 +1817,19 @@ mli_status mli_krn_avepool_chw_fx16_k1x2_nopad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2013,20 +1841,10 @@ mli_status mli_krn_avepool_chw_fx16_k1x2_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2043,9 +1861,13 @@ mli_status mli_krn_avepool_chw_fx16_k1x3_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2065,20 +1887,19 @@ mli_status mli_krn_avepool_chw_fx16_k1x3_nopad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2090,20 +1911,10 @@ mli_status mli_krn_avepool_chw_fx16_k1x3_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2120,9 +1931,13 @@ mli_status mli_krn_avepool_chw_fx16_knx1_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2142,20 +1957,19 @@ mli_status mli_krn_avepool_chw_fx16_knx1_nopad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2167,20 +1981,10 @@ mli_status mli_krn_avepool_chw_fx16_knx1_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2197,9 +2001,13 @@ mli_status mli_krn_avepool_chw_fx16_k2x1_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2219,20 +2027,19 @@ mli_status mli_krn_avepool_chw_fx16_k2x1_nopad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2244,20 +2051,10 @@ mli_status mli_krn_avepool_chw_fx16_k2x1_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2274,9 +2071,13 @@ mli_status mli_krn_avepool_chw_fx16_k3x1_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2296,20 +2097,19 @@ mli_status mli_krn_avepool_chw_fx16_k3x1_nopad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2321,20 +2121,10 @@ mli_status mli_krn_avepool_chw_fx16_k3x1_nopad(const mli_tensor * in, const mli_
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2351,9 +2141,13 @@ mli_status mli_krn_avepool_chw_fx16_generic(const mli_tensor * in, const mli_poo
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2373,20 +2167,19 @@ mli_status mli_krn_avepool_chw_fx16_generic(const mli_tensor * in, const mli_poo
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2398,20 +2191,10 @@ mli_status mli_krn_avepool_chw_fx16_generic(const mli_tensor * in, const mli_poo
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_avepool_chw_fx8.cc
+++ b/lib/src/kernels/pooling/mli_krn_avepool_chw_fx8.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_avepool_chw_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -63,20 +67,19 @@ mli_status mli_krn_avepool_chw_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -88,20 +91,10 @@ mli_status mli_krn_avepool_chw_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -118,9 +111,13 @@ mli_status mli_krn_avepool_chw_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -140,20 +137,19 @@ mli_status mli_krn_avepool_chw_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -165,20 +161,10 @@ mli_status mli_krn_avepool_chw_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -195,9 +181,13 @@ mli_status mli_krn_avepool_chw_fx8_k4x4_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -217,20 +207,19 @@ mli_status mli_krn_avepool_chw_fx8_k4x4_krnpad(const mli_tensor * in, const mli_
 #if 4
     MLI_CHECK_AND_FIX(kernel_height, 4);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -242,20 +231,10 @@ mli_status mli_krn_avepool_chw_fx8_k4x4_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -272,9 +251,13 @@ mli_status mli_krn_avepool_chw_fx8_k5x5_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -294,20 +277,19 @@ mli_status mli_krn_avepool_chw_fx8_k5x5_krnpad(const mli_tensor * in, const mli_
 #if 5
     MLI_CHECK_AND_FIX(kernel_height, 5);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -319,20 +301,10 @@ mli_status mli_krn_avepool_chw_fx8_k5x5_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -349,9 +321,13 @@ mli_status mli_krn_avepool_chw_fx8_k6x6_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -371,20 +347,19 @@ mli_status mli_krn_avepool_chw_fx8_k6x6_krnpad(const mli_tensor * in, const mli_
 #if 6
     MLI_CHECK_AND_FIX(kernel_height, 6);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -396,20 +371,10 @@ mli_status mli_krn_avepool_chw_fx8_k6x6_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -426,9 +391,13 @@ mli_status mli_krn_avepool_chw_fx8_k7x7_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -448,20 +417,19 @@ mli_status mli_krn_avepool_chw_fx8_k7x7_krnpad(const mli_tensor * in, const mli_
 #if 7
     MLI_CHECK_AND_FIX(kernel_height, 7);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -473,20 +441,10 @@ mli_status mli_krn_avepool_chw_fx8_k7x7_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -503,9 +461,13 @@ mli_status mli_krn_avepool_chw_fx8_k8x8_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -525,20 +487,19 @@ mli_status mli_krn_avepool_chw_fx8_k8x8_krnpad(const mli_tensor * in, const mli_
 #if 8
     MLI_CHECK_AND_FIX(kernel_height, 8);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -550,20 +511,10 @@ mli_status mli_krn_avepool_chw_fx8_k8x8_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -580,9 +531,13 @@ mli_status mli_krn_avepool_chw_fx8_k9x9_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -602,20 +557,19 @@ mli_status mli_krn_avepool_chw_fx8_k9x9_krnpad(const mli_tensor * in, const mli_
 #if 9
     MLI_CHECK_AND_FIX(kernel_height, 9);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -627,20 +581,10 @@ mli_status mli_krn_avepool_chw_fx8_k9x9_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -657,9 +601,13 @@ mli_status mli_krn_avepool_chw_fx8_k10x10_krnpad(const mli_tensor * in, const ml
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -679,20 +627,19 @@ mli_status mli_krn_avepool_chw_fx8_k10x10_krnpad(const mli_tensor * in, const ml
 #if 10
     MLI_CHECK_AND_FIX(kernel_height, 10);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -704,20 +651,10 @@ mli_status mli_krn_avepool_chw_fx8_k10x10_krnpad(const mli_tensor * in, const ml
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -734,9 +671,13 @@ mli_status mli_krn_avepool_chw_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -756,20 +697,19 @@ mli_status mli_krn_avepool_chw_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -781,20 +721,10 @@ mli_status mli_krn_avepool_chw_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -811,9 +741,13 @@ mli_status mli_krn_avepool_chw_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -833,20 +767,19 @@ mli_status mli_krn_avepool_chw_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -858,20 +791,10 @@ mli_status mli_krn_avepool_chw_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -888,9 +811,13 @@ mli_status mli_krn_avepool_chw_fx8_k4x4_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -910,20 +837,19 @@ mli_status mli_krn_avepool_chw_fx8_k4x4_nopad(const mli_tensor * in, const mli_p
 #if 4
     MLI_CHECK_AND_FIX(kernel_height, 4);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -935,20 +861,10 @@ mli_status mli_krn_avepool_chw_fx8_k4x4_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -965,9 +881,13 @@ mli_status mli_krn_avepool_chw_fx8_k5x5_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -987,20 +907,19 @@ mli_status mli_krn_avepool_chw_fx8_k5x5_nopad(const mli_tensor * in, const mli_p
 #if 5
     MLI_CHECK_AND_FIX(kernel_height, 5);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1012,20 +931,10 @@ mli_status mli_krn_avepool_chw_fx8_k5x5_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1042,9 +951,13 @@ mli_status mli_krn_avepool_chw_fx8_k6x6_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1064,20 +977,19 @@ mli_status mli_krn_avepool_chw_fx8_k6x6_nopad(const mli_tensor * in, const mli_p
 #if 6
     MLI_CHECK_AND_FIX(kernel_height, 6);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1089,20 +1001,10 @@ mli_status mli_krn_avepool_chw_fx8_k6x6_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1119,9 +1021,13 @@ mli_status mli_krn_avepool_chw_fx8_k7x7_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1141,20 +1047,19 @@ mli_status mli_krn_avepool_chw_fx8_k7x7_nopad(const mli_tensor * in, const mli_p
 #if 7
     MLI_CHECK_AND_FIX(kernel_height, 7);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1166,20 +1071,10 @@ mli_status mli_krn_avepool_chw_fx8_k7x7_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1196,9 +1091,13 @@ mli_status mli_krn_avepool_chw_fx8_k8x8_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1218,20 +1117,19 @@ mli_status mli_krn_avepool_chw_fx8_k8x8_nopad(const mli_tensor * in, const mli_p
 #if 8
     MLI_CHECK_AND_FIX(kernel_height, 8);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1243,20 +1141,10 @@ mli_status mli_krn_avepool_chw_fx8_k8x8_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1273,9 +1161,13 @@ mli_status mli_krn_avepool_chw_fx8_k9x9_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1295,20 +1187,19 @@ mli_status mli_krn_avepool_chw_fx8_k9x9_nopad(const mli_tensor * in, const mli_p
 #if 9
     MLI_CHECK_AND_FIX(kernel_height, 9);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1320,20 +1211,10 @@ mli_status mli_krn_avepool_chw_fx8_k9x9_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1350,9 +1231,13 @@ mli_status mli_krn_avepool_chw_fx8_k10x10_nopad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1372,20 +1257,19 @@ mli_status mli_krn_avepool_chw_fx8_k10x10_nopad(const mli_tensor * in, const mli
 #if 10
     MLI_CHECK_AND_FIX(kernel_height, 10);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1397,20 +1281,10 @@ mli_status mli_krn_avepool_chw_fx8_k10x10_nopad(const mli_tensor * in, const mli
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1427,9 +1301,13 @@ mli_status mli_krn_avepool_chw_fx8_k1xn_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1449,20 +1327,19 @@ mli_status mli_krn_avepool_chw_fx8_k1xn_krnpad(const mli_tensor * in, const mli_
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1474,20 +1351,10 @@ mli_status mli_krn_avepool_chw_fx8_k1xn_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1504,9 +1371,13 @@ mli_status mli_krn_avepool_chw_fx8_k1x2_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1526,20 +1397,19 @@ mli_status mli_krn_avepool_chw_fx8_k1x2_krnpad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1551,20 +1421,10 @@ mli_status mli_krn_avepool_chw_fx8_k1x2_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1581,9 +1441,13 @@ mli_status mli_krn_avepool_chw_fx8_k1x3_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1603,20 +1467,19 @@ mli_status mli_krn_avepool_chw_fx8_k1x3_krnpad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1628,20 +1491,10 @@ mli_status mli_krn_avepool_chw_fx8_k1x3_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1658,9 +1511,13 @@ mli_status mli_krn_avepool_chw_fx8_knx1_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1680,20 +1537,19 @@ mli_status mli_krn_avepool_chw_fx8_knx1_krnpad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1705,20 +1561,10 @@ mli_status mli_krn_avepool_chw_fx8_knx1_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1735,9 +1581,13 @@ mli_status mli_krn_avepool_chw_fx8_k2x1_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1757,20 +1607,19 @@ mli_status mli_krn_avepool_chw_fx8_k2x1_krnpad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1782,20 +1631,10 @@ mli_status mli_krn_avepool_chw_fx8_k2x1_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1812,9 +1651,13 @@ mli_status mli_krn_avepool_chw_fx8_k3x1_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1834,20 +1677,19 @@ mli_status mli_krn_avepool_chw_fx8_k3x1_krnpad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1859,20 +1701,10 @@ mli_status mli_krn_avepool_chw_fx8_k3x1_krnpad(const mli_tensor * in, const mli_
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1889,9 +1721,13 @@ mli_status mli_krn_avepool_chw_fx8_k1xn_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1911,20 +1747,19 @@ mli_status mli_krn_avepool_chw_fx8_k1xn_nopad(const mli_tensor * in, const mli_p
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -1936,20 +1771,10 @@ mli_status mli_krn_avepool_chw_fx8_k1xn_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1966,9 +1791,13 @@ mli_status mli_krn_avepool_chw_fx8_k1x2_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1988,20 +1817,19 @@ mli_status mli_krn_avepool_chw_fx8_k1x2_nopad(const mli_tensor * in, const mli_p
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2013,20 +1841,10 @@ mli_status mli_krn_avepool_chw_fx8_k1x2_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2043,9 +1861,13 @@ mli_status mli_krn_avepool_chw_fx8_k1x3_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2065,20 +1887,19 @@ mli_status mli_krn_avepool_chw_fx8_k1x3_nopad(const mli_tensor * in, const mli_p
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2090,20 +1911,10 @@ mli_status mli_krn_avepool_chw_fx8_k1x3_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2120,9 +1931,13 @@ mli_status mli_krn_avepool_chw_fx8_knx1_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2142,20 +1957,19 @@ mli_status mli_krn_avepool_chw_fx8_knx1_nopad(const mli_tensor * in, const mli_p
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2167,20 +1981,10 @@ mli_status mli_krn_avepool_chw_fx8_knx1_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2197,9 +2001,13 @@ mli_status mli_krn_avepool_chw_fx8_k2x1_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2219,20 +2027,19 @@ mli_status mli_krn_avepool_chw_fx8_k2x1_nopad(const mli_tensor * in, const mli_p
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2244,20 +2051,10 @@ mli_status mli_krn_avepool_chw_fx8_k2x1_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2274,9 +2071,13 @@ mli_status mli_krn_avepool_chw_fx8_k3x1_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2296,20 +2097,19 @@ mli_status mli_krn_avepool_chw_fx8_k3x1_nopad(const mli_tensor * in, const mli_p
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2321,20 +2121,10 @@ mli_status mli_krn_avepool_chw_fx8_k3x1_nopad(const mli_tensor * in, const mli_p
     avepool_chw_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2351,9 +2141,13 @@ mli_status mli_krn_avepool_chw_fx8_generic(const mli_tensor * in, const mli_pool
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_CHW];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2373,20 +2167,19 @@ mli_status mli_krn_avepool_chw_fx8_generic(const mli_tensor * in, const mli_pool
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_CHW];
-    const int in_width = in->shape[FMAP_W_DIM_CHW];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -2398,20 +2191,10 @@ mli_status mli_krn_avepool_chw_fx8_generic(const mli_tensor * in, const mli_pool
     avepool_chw_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_avepool_hwc.h
+++ b/lib/src/kernels/pooling/mli_krn_avepool_hwc.h
@@ -15,6 +15,7 @@
 #include "mli_config.h"
 #include "mli_debug.h"
 #include "mli_helpers_api.h"
+#include "mli_private_types.h"
 #include "mli_prv_dsp.h"
 
 /******************************************************************************
@@ -29,13 +30,8 @@ static inline void __attribute__((always_inline)) avepool_hwc_nopad(
         const int row_end,
         const int clmn_beg,
         const int clmn_end,
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        MLI_OUT_PTR(io_T) __restrict out_ftrs,
-        const int channels,
-        const int in_width,
-        const int in_height,
-        const int out_width,
-        const int out_height,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
         const int kernel_height,
         const int kernel_width,
         const int stride_height,
@@ -46,58 +42,59 @@ static inline void __attribute__((always_inline)) avepool_hwc_nopad(
         const int padding_bot) {
     (void)padding_right;
     (void)padding_bot;
-    
+
     const unsigned int max_kernel_size = kernel_width * kernel_height;
     const int number_rows = row_end - row_beg;
     const int number_clmns = clmn_end - clmn_beg;
-    const int goto_next_row = channels * in_width * stride_height;
-    const int goto_next_clmn = channels * stride_width;
-    const int compensation_inp_width_lp = channels * stride_width * number_clmns;
-    const int compensation_inp_height_lp = goto_next_row  * number_rows;
-    const int out_compensation_row_loop = channels * out_width * number_rows;
-    const int out_compensation_clmn_loop = channels * number_clmns;
+    const int compensation_inp_width_lp  = in.col_mem_stride * stride_width * number_clmns;
+    const int compensation_inp_height_lp = in.row_mem_stride * stride_height * number_rows;
+    const int out_compensation_row_loop  = out.row_mem_stride * number_rows;
+    const int out_compensation_clmn_loop = out.col_mem_stride * number_clmns;
     int16_t mul = 0;
 
-    in_ftrs  += ((row_beg * stride_height - padding_top) * in_width +            // move to row
-                 (clmn_beg * stride_width - padding_left)) * channels;           // move to column
-    out_ftrs += (row_beg  * out_width +                                          // move to row
-                 clmn_beg)  * channels;                                           // move to column
+    MLI_PTR(io_T) in_ftrs = in.ptr
+            + in.row_mem_stride * (row_beg * stride_height - padding_top)   // move to row
+            + in.col_mem_stride * (clmn_beg * stride_width - padding_left); // move to column
+    MLI_OUT_PTR(io_T) out_ftrs = out.ptr
+            + out.row_mem_stride * row_beg   // move to row
+            + out.col_mem_stride * clmn_beg; // move to column
     int shift = 0;
     // in case of average pooling, the sum needs to be divided by the kernel size.
     // calculate 1/(rows*clmns) to get a multiplication factor and shift value.
     get_mul_shift_value(max_kernel_size, &mul, &shift);
 
-    for (int ch_idx = 0; ch_idx < (channels - 1); ch_idx += 2) {
+    for (int ch_idx = 0; ch_idx < (in.ch - 1); ch_idx += 2) {
         for (int H_idx = 0; H_idx < number_rows; H_idx++) {
             for (int W_idx = 0; W_idx < number_clmns; W_idx++) {
-                auto v2acc = reduce_sum2D_hwc_v(in_ftrs, kernel_width, kernel_height, channels, in_width, mul);
+                auto v2acc = reduce_sum2D_hwc_v(in_ftrs, kernel_width, kernel_height,
+                        in.col_mem_stride, in.row_mem_stride, mul);
                 mli_prv_clip_and_store_output_v(out_ftrs, &v2acc, shift);
-                in_ftrs += goto_next_clmn; //go to the next input column
-                out_ftrs += channels; //go to the next output column without out stride
+                in_ftrs +=  in.col_mem_stride * stride_width; // go to the next input column
+                out_ftrs += out.col_mem_stride;               // go to the next output column
             } // for W_idx
             // go to the next row given compensation of previous loops incrementing
-            in_ftrs += goto_next_row - compensation_inp_width_lp;
-            out_ftrs += out_width * channels - out_compensation_clmn_loop;
+            in_ftrs += in.row_mem_stride * stride_height - compensation_inp_width_lp;
+            out_ftrs += out.row_mem_stride - out_compensation_clmn_loop;
         } // for H_idx
         // go to the next channel given compensation of previous loops incrementing 
         in_ftrs  += 2 - compensation_inp_height_lp;
         // go to next channel with compensation of previous loops incrementing
         out_ftrs += 2 - out_compensation_row_loop;
-    } // for ch_idx 
+    } // for ch_idx
 
-
-    if(channels & 1){
+    if(in.ch & 1){
         for (int H_idx = 0; H_idx < number_rows; H_idx++) {
             for (int W_idx = 0; W_idx < number_clmns; W_idx++) {
-                auto acc = reduce_sum2D_hwc(in_ftrs, kernel_width, kernel_height, channels, in_width, mul);
+                auto acc = reduce_sum2D_hwc(in_ftrs, kernel_width, kernel_height,
+                        in.col_mem_stride, in.row_mem_stride, mul);
                 mli_prv_shift_clip_and_store_output(out_ftrs, &acc, shift);
                 // Write results
-                in_ftrs += goto_next_clmn; //go to the next input column
-                out_ftrs += channels; //go to the next output column without out stride
+                in_ftrs += in.col_mem_stride * stride_width; // go to the next input column
+                out_ftrs += out.col_mem_stride;              // go to the next output column
             } // for W_idx 
             // go to the next row given compensation of previous loops incrementing
-            out_ftrs += out_width * channels - out_compensation_clmn_loop;
-            in_ftrs += goto_next_row - compensation_inp_width_lp;
+            in_ftrs += in.row_mem_stride * stride_height - compensation_inp_width_lp;
+            out_ftrs += out.row_mem_stride - out_compensation_clmn_loop;
         } // for H_idx
         out_ftrs += 1 - out_compensation_row_loop;
     }
@@ -109,13 +106,8 @@ static inline void __attribute__((always_inline)) avepool_hwc(
         const int row_end,
         const int clmn_beg,
         const int clmn_end,
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        MLI_OUT_PTR(io_T) __restrict out_ftrs,
-        const int channels,
-        const int in_width,
-        const int in_height,
-        const int out_width,
-        const int out_height,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
         const int kernel_height,
         const int kernel_width,
         const int stride_height,
@@ -126,16 +118,17 @@ static inline void __attribute__((always_inline)) avepool_hwc(
         const int padding_bot) {
     (void)padding_right;
     (void)padding_bot;
-    
+
     const int number_rows = row_end - row_beg;
     const int number_clmns = clmn_end - clmn_beg;
-    const int out_compensation_row_loop = channels * out_width * number_rows;
-    const int out_compensation_clmn_loop = channels * number_clmns;
+    const int out_compensation_row_loop = out.row_mem_stride * number_rows;
+    const int out_compensation_clmn_loop = out.col_mem_stride * number_clmns;
 
-    out_ftrs += (row_beg  * out_width +  // move to row
-                 clmn_beg)  * channels;   // move to column
+    MLI_OUT_PTR(io_T) out_ftrs = out.ptr
+            + out.row_mem_stride * row_beg   // move to row
+            + out.col_mem_stride * clmn_beg; // move to column
 
-    for (int ch_idx = 0; ch_idx < channels; ch_idx++) {
+    for (int ch_idx = 0; ch_idx < in.ch; ch_idx++) {
         for (int H_idx = row_beg; H_idx < row_end; H_idx++) {
             for (int W_idx = clmn_beg; W_idx < clmn_end; W_idx++) {
                 // Define area of input and filter for convolution
@@ -143,8 +136,8 @@ static inline void __attribute__((always_inline)) avepool_hwc(
                 int top_comp = -MIN((int)(H_idx * stride_height)- padding_top, 0);
                 int left_comp = -MIN((int)(W_idx * stride_width)- padding_left, 0);
 
-                int right_comp = -MIN((int)in_width - ((int32_t)(W_idx * stride_width)- padding_left + kernel_width), 0);
-                int bottom_comp = -MIN((int)in_height - ((int32_t)(H_idx * stride_height)- padding_top + kernel_height), 0);
+                int right_comp = -MIN((int)in.width - ((int32_t)(W_idx * stride_width)- padding_left + kernel_width), 0);
+                int bottom_comp = -MIN((int)in.height - ((int32_t)(H_idx * stride_height)- padding_top + kernel_height), 0);
 
                 int rows = kernel_height - top_comp - bottom_comp;
                 int clmns = kernel_width - right_comp - left_comp;
@@ -156,15 +149,16 @@ static inline void __attribute__((always_inline)) avepool_hwc(
                 int shift = 0;
                 get_mul_shift_value(kernel_size, &mul, &shift);
 
-                MLI_PTR(io_T) in_ptr = (MLI_PTR(io_T))in_ftrs +                                     // starting point
-                        channels * in_width * (H_idx * stride_height - padding_top + top_comp) +    // move to row
-                        channels * ((W_idx * stride_width) - padding_left + left_comp) +            // move to column
-                        ch_idx;                                                                     // move to channel
-                mli_acc40_t acc = reduce_sum2D_hwc(in_ptr, clmns, rows, channels, in_width, mul);
+                MLI_PTR(io_T) in_ptr = in.ptr                                                   // starting point
+                        + in.row_mem_stride * (H_idx * stride_height - padding_top + top_comp)  // move to row
+                        + in.col_mem_stride * (W_idx * stride_width - padding_left + left_comp) // move to column
+                        + ch_idx;                                                               // move to channel
+                mli_acc40_t acc = reduce_sum2D_hwc(in_ptr, clmns, rows,
+                        in.col_mem_stride, in.row_mem_stride, mul);
                 mli_prv_shift_clip_and_store_output(out_ftrs, &acc, shift);
-                out_ftrs += channels; //go to the next output column without out stride
+                out_ftrs += out.col_mem_stride; //go to the next output column without out stride
             } // for W_idx 
-            out_ftrs += out_width * channels - out_compensation_clmn_loop;
+            out_ftrs += out.row_mem_stride - out_compensation_clmn_loop;
         } // for H_idx
         // go to next channel with compensation of previous loops incrementing
         out_ftrs += 1 - out_compensation_row_loop;
@@ -177,13 +171,8 @@ static inline void __attribute__((always_inline)) avepool_hwc_krnpad(
         int row_end,
         int clmn_beg,
         int clmn_end,
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        MLI_OUT_PTR(io_T) __restrict out_ftrs,
-        const int channels,
-        const int in_width,
-        const int in_height,
-        const int out_width,
-        const int out_height,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
         const int kernel_height,
         const int kernel_width,
         const int stride_height,
@@ -196,16 +185,16 @@ static inline void __attribute__((always_inline)) avepool_hwc_krnpad(
     //=======================================================================
 
     row_beg = CEIL_DIV(padding_top, stride_height);
-    row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+    row_end = out.height - CEIL_DIV(padding_bot, stride_height);
     clmn_beg = CEIL_DIV(padding_left, stride_width);
-    clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
+    clmn_end = out.width - CEIL_DIV(padding_right, stride_width);
 
     if ((row_end - row_beg > 0) && (clmn_end - clmn_beg > 0)) {
         avepool_hwc_nopad(
                 row_beg, row_end, clmn_beg, clmn_end,
-                in_ftrs, out_ftrs, channels, in_width,
-                in_height, out_width, out_height, kernel_height,
-                kernel_width, stride_height, stride_width,
+                in, out,
+                kernel_height, kernel_width,
+                stride_height, stride_width,
                 padding_top, padding_left, padding_right, padding_bot);
     }
 
@@ -219,33 +208,31 @@ static inline void __attribute__((always_inline)) avepool_hwc_krnpad(
             areas[areas_num].row_beg = 0;
             areas[areas_num].row_end = CEIL_DIV(padding_top, stride_height);
             areas[areas_num].clmn_beg = 0;
-            areas[areas_num++].clmn_end = out_width;
+            areas[areas_num++].clmn_end = out.width;
         }
         if (padding_bot) {
-            areas[areas_num].row_beg = out_height - CEIL_DIV(padding_bot, stride_height);
-            areas[areas_num].row_end = out_height;
+            areas[areas_num].row_beg = out.height - CEIL_DIV(padding_bot, stride_height);
+            areas[areas_num].row_end = out.height;
             areas[areas_num].clmn_beg = 0;
-            areas[areas_num++].clmn_end = out_width;
+            areas[areas_num++].clmn_end = out.width;
         }
         if (padding_left) {
             areas[areas_num].row_beg = CEIL_DIV(padding_top, stride_height);
-            areas[areas_num].row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+            areas[areas_num].row_end = out.height - CEIL_DIV(padding_bot, stride_height);
             areas[areas_num].clmn_beg = 0;
             areas[areas_num++].clmn_end = CEIL_DIV(padding_left, stride_width);
         }
         if (padding_right) {
             areas[areas_num].row_beg = CEIL_DIV(padding_top, stride_height);
-            areas[areas_num].row_end = out_height - CEIL_DIV(padding_bot, stride_height);
-            areas[areas_num].clmn_beg = out_width - CEIL_DIV(padding_right, stride_width);
-            areas[areas_num++].clmn_end = out_width;
+            areas[areas_num].row_end = out.height - CEIL_DIV(padding_bot, stride_height);
+            areas[areas_num].clmn_beg = out.width - CEIL_DIV(padding_right, stride_width);
+            areas[areas_num++].clmn_end = out.width;
         }
 
         for (int i = 0; i < areas_num; i++) {
             avepool_hwc(
                     areas[i].row_beg, areas[i].row_end, areas[i].clmn_beg, areas[i].clmn_end,
-                    in_ftrs, out_ftrs,
-                    channels, in_width, in_height,
-                    out_width, out_height,
+                    in, out,
                     kernel_height, kernel_width,
                     stride_height, stride_width,
                     padding_top, padding_left, padding_right, padding_bot);

--- a/lib/src/kernels/pooling/mli_krn_avepool_hwc_fx16.cc
+++ b/lib/src/kernels/pooling/mli_krn_avepool_hwc_fx16.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_avepool_hwc_fx16_k2x2_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -63,20 +67,19 @@ mli_status mli_krn_avepool_hwc_fx16_k2x2_nopad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -88,20 +91,10 @@ mli_status mli_krn_avepool_hwc_fx16_k2x2_nopad(const mli_tensor * in, const mli_
     avepool_hwc_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -118,9 +111,13 @@ mli_status mli_krn_avepool_hwc_fx16_k3x3_nopad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -140,20 +137,19 @@ mli_status mli_krn_avepool_hwc_fx16_k3x3_nopad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -165,20 +161,10 @@ mli_status mli_krn_avepool_hwc_fx16_k3x3_nopad(const mli_tensor * in, const mli_
     avepool_hwc_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -195,9 +181,13 @@ mli_status mli_krn_avepool_hwc_fx16_k2x2_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -217,20 +207,19 @@ mli_status mli_krn_avepool_hwc_fx16_k2x2_krnpad(const mli_tensor * in, const mli
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -242,20 +231,10 @@ mli_status mli_krn_avepool_hwc_fx16_k2x2_krnpad(const mli_tensor * in, const mli
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -272,9 +251,13 @@ mli_status mli_krn_avepool_hwc_fx16_k3x3_krnpad(const mli_tensor * in, const mli
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -294,20 +277,19 @@ mli_status mli_krn_avepool_hwc_fx16_k3x3_krnpad(const mli_tensor * in, const mli
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -319,20 +301,10 @@ mli_status mli_krn_avepool_hwc_fx16_k3x3_krnpad(const mli_tensor * in, const mli
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -349,9 +321,13 @@ mli_status mli_krn_avepool_hwc_fx16_generic(const mli_tensor * in, const mli_poo
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -371,20 +347,19 @@ mli_status mli_krn_avepool_hwc_fx16_generic(const mli_tensor * in, const mli_poo
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -396,20 +371,10 @@ mli_status mli_krn_avepool_hwc_fx16_generic(const mli_tensor * in, const mli_poo
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_avepool_hwc_fx8.cc
+++ b/lib/src/kernels/pooling/mli_krn_avepool_hwc_fx8.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_avepool_hwc_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -63,20 +67,19 @@ mli_status mli_krn_avepool_hwc_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -88,20 +91,10 @@ mli_status mli_krn_avepool_hwc_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
     avepool_hwc_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -118,9 +111,13 @@ mli_status mli_krn_avepool_hwc_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -140,20 +137,19 @@ mli_status mli_krn_avepool_hwc_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -165,20 +161,10 @@ mli_status mli_krn_avepool_hwc_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
     avepool_hwc_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -195,9 +181,13 @@ mli_status mli_krn_avepool_hwc_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -217,20 +207,19 @@ mli_status mli_krn_avepool_hwc_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -242,20 +231,10 @@ mli_status mli_krn_avepool_hwc_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -272,9 +251,13 @@ mli_status mli_krn_avepool_hwc_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -294,20 +277,19 @@ mli_status mli_krn_avepool_hwc_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -319,20 +301,10 @@ mli_status mli_krn_avepool_hwc_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -349,9 +321,13 @@ mli_status mli_krn_avepool_hwc_fx8_generic(const mli_tensor * in, const mli_pool
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -371,20 +347,19 @@ mli_status mli_krn_avepool_hwc_fx8_generic(const mli_tensor * in, const mli_pool
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -396,20 +371,10 @@ mli_status mli_krn_avepool_hwc_fx8_generic(const mli_tensor * in, const mli_pool
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_avepool_hwc_sa8.cc
+++ b/lib/src/kernels/pooling/mli_krn_avepool_hwc_sa8.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_avepool_hwc_sa8_k2x2_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -63,20 +67,19 @@ mli_status mli_krn_avepool_hwc_sa8_k2x2_nopad(const mli_tensor * in, const mli_p
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -88,20 +91,10 @@ mli_status mli_krn_avepool_hwc_sa8_k2x2_nopad(const mli_tensor * in, const mli_p
     avepool_hwc_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
 
     return MLI_STATUS_OK;
 }
@@ -118,9 +111,13 @@ mli_status mli_krn_avepool_hwc_sa8_k3x3_nopad(const mli_tensor * in, const mli_p
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -140,20 +137,19 @@ mli_status mli_krn_avepool_hwc_sa8_k3x3_nopad(const mli_tensor * in, const mli_p
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -165,20 +161,10 @@ mli_status mli_krn_avepool_hwc_sa8_k3x3_nopad(const mli_tensor * in, const mli_p
     avepool_hwc_nopad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
 
     return MLI_STATUS_OK;
 }
@@ -195,9 +181,13 @@ mli_status mli_krn_avepool_hwc_sa8_k2x2_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -217,20 +207,19 @@ mli_status mli_krn_avepool_hwc_sa8_k2x2_krnpad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -242,20 +231,10 @@ mli_status mli_krn_avepool_hwc_sa8_k2x2_krnpad(const mli_tensor * in, const mli_
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
 
     return MLI_STATUS_OK;
 }
@@ -272,9 +251,13 @@ mli_status mli_krn_avepool_hwc_sa8_k3x3_krnpad(const mli_tensor * in, const mli_
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -294,20 +277,19 @@ mli_status mli_krn_avepool_hwc_sa8_k3x3_krnpad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -319,20 +301,10 @@ mli_status mli_krn_avepool_hwc_sa8_k3x3_krnpad(const mli_tensor * in, const mli_
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
 
     return MLI_STATUS_OK;
 }
@@ -349,9 +321,13 @@ mli_status mli_krn_avepool_hwc_sa8_generic(const mli_tensor * in, const mli_pool
     int padding_bot = cfg->padding_bottom;
     int padding_left = cfg->padding_left;
     int padding_right = cfg->padding_right;
-    int channels_num = in->shape[FMAP_C_DIM_HWC];
     int kernel_height = cfg->kernel_height;
     int kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -371,20 +347,19 @@ mli_status mli_krn_avepool_hwc_sa8_generic(const mli_tensor * in, const mli_pool
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int in_height = in->shape[FMAP_H_DIM_HWC];
-    const int in_width = in->shape[FMAP_W_DIM_HWC];
+    const int out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int row_beg = 0;
     const int row_end = out_height;
@@ -396,20 +371,10 @@ mli_status mli_krn_avepool_hwc_sa8_generic(const mli_tensor * in, const mli_pool
     avepool_hwc_krnpad(
         row_beg, row_end,
         clmn_beg, clmn_end,
-        in_ftrs, out_ftrs,
-        channels_num, in_width, in_height,
-        out_width, out_height,
+        in_prv, out_prv,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_left, padding_right, padding_bot);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_maxpool_chw.h
+++ b/lib/src/kernels/pooling/mli_krn_maxpool_chw.h
@@ -18,6 +18,7 @@
 #include "mli_debug.h"
 #include "mli_helpers_api.h"
 #include "mli_math.h"
+#include "mli_private_types.h"
 #include "mli_prv_dsp.h"
 #include "mli_prv_load_store.h"
 
@@ -182,17 +183,12 @@ static inline io_T __attribute__((always_inline)) reduce_max2D_small(
 
 template <typename io_T>
 static inline void __attribute__((always_inline)) maxpool_chw_nopad(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        MLI_OUT_PTR(io_T) __restrict out_ftrs,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
         const int row_begin,
         const int row_end,
         const int clmn_begin,
         const int clmn_end,
-        const int channels_num,
-        const int in_width,
-        const int in_height,
-        const int out_width,
-        const int out_height,
         const int kernel_height,
         const int kernel_width,
         const int stride_height,
@@ -202,65 +198,67 @@ static inline void __attribute__((always_inline)) maxpool_chw_nopad(
         const int padding_left,
         const int padding_right,
         const int fixed_padding) {
-    MLI_OUT_PTR(io_T) __restrict out_ptr = out_ftrs + row_begin * out_width + clmn_begin;
-    const MLI_PTR(io_T) __restrict in_ptr =
-            in_ftrs + (row_begin * stride_height - padding_top) * in_width + (clmn_begin * stride_width - padding_left);
+
+    MLI_ASSERT(in.col_mem_stride == 1 && out.col_mem_stride == 1);
+
+    MLI_OUT_PTR(io_T) __restrict out_ptr = out.ptr
+            + out.col_mem_stride * clmn_begin
+            + out.row_mem_stride * row_begin;
+    const MLI_PTR(io_T) __restrict in_ptr = in.ptr
+            + in.col_mem_stride * (clmn_begin * stride_width - padding_left)
+            + in.row_mem_stride * (row_begin * stride_height - padding_top);
+
     if (kernel_width < 4 && kernel_height <= REDUCE_MAX2D_UNROLL_FACTOR_FOR_HEIGHT) {
-        __builtin_assume(channels_num > 0);
-        for (int ch_idx = 0; ch_idx < channels_num; ch_idx++) {
+        __builtin_assume(in.ch > 0);
+        for (int ch_idx = 0; ch_idx < in.ch; ch_idx++) {
             for (int j = 0; j < (row_end - row_begin); j++) {
 LOOP_PIPELINE_ENABLE 
 #pragma unroll 2
                 for (int k = 0; k < (clmn_end - clmn_begin); k++) {
                     // Core Max
-                    io_T max_val = reduce_max2D(in_ptr, kernel_width, kernel_height, in_width, true);
+                    io_T max_val = reduce_max2D(in_ptr, kernel_width, kernel_height, in.row_mem_stride, true);
 
-                    in_ptr += stride_width;
+                    in_ptr += in.col_mem_stride * stride_width;
                     // Write results
                     *out_ptr++ = max_val;
                     MAXPOOL_DBG_PRINT(ch_idx, j + row_begin, k + clmn_begin, max_val);
                 }
-                in_ptr += in_width * stride_height + (clmn_begin - clmn_end) * stride_width;
-                out_ptr += out_width + clmn_begin - clmn_end;
+                in_ptr += in.row_mem_stride * stride_height - (in.col_mem_stride * stride_width * (clmn_end - clmn_begin));
+                out_ptr += out.row_mem_stride - (clmn_end - clmn_begin);
             }
-            in_ptr += in_width * (in_height + (row_begin - row_end) * stride_height);
-            out_ptr += out_width * (out_height + row_begin - row_end);
+            in_ptr += in.ch_mem_stride - (in.row_mem_stride * stride_height * (row_end - row_begin));
+            out_ptr += out.ch_mem_stride -  (out.row_mem_stride * (row_end - row_begin));
         }
     } else {
-        __builtin_assume(channels_num > 0);
-        for (int ch_idx = 0; ch_idx < channels_num; ch_idx++) {
+        __builtin_assume(in.ch > 0);
+        for (int ch_idx = 0; ch_idx < in.ch; ch_idx++) {
             for (int j = 0; j < (row_end - row_begin); j++) {
                 for (int k = 0; k < (clmn_end - clmn_begin); k++) {
                     // Core Max
-                    io_T max_val = reduce_max2D(in_ptr, kernel_width, kernel_height, in_width, true);
+                    io_T max_val = reduce_max2D(in_ptr, kernel_width, kernel_height, in.row_mem_stride, true);
 
-                    in_ptr += stride_width;
+                    in_ptr += in.col_mem_stride * stride_width;
                     // Write results
                     *out_ptr++ = max_val;
                     MAXPOOL_DBG_PRINT(ch_idx, j + row_begin, k + clmn_begin, max_val);
                 }
-                in_ptr += in_width * stride_height + (clmn_begin - clmn_end) * stride_width;
-                out_ptr += out_width + clmn_begin - clmn_end;
+                in_ptr += in.row_mem_stride * stride_height - (in.col_mem_stride * stride_width * (clmn_end - clmn_begin));
+                out_ptr += out.row_mem_stride - (clmn_end - clmn_begin);
             }
-            in_ptr += in_width * (in_height + (row_begin - row_end) * stride_height);
-            out_ptr += out_width * (out_height + row_begin - row_end);
+            in_ptr += in.ch_mem_stride - (in.row_mem_stride * stride_height * (row_end - row_begin));
+            out_ptr += out.ch_mem_stride -  (out.row_mem_stride * (row_end - row_begin));
         }
     }
 }
 
 template <typename io_T>
 static inline void __attribute__((always_inline)) maxpool_chw(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        MLI_OUT_PTR(io_T) __restrict out_ftrs,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
         const int row_begin,
         const int row_end,
         const int clmn_begin,
         const int clmn_end,
-        const int channels_num,
-        const int in_width,
-        const int in_height,
-        const int out_width,
-        const int out_height,
         const int kernel_height,
         const int kernel_width,
         const int stride_height,
@@ -270,9 +268,14 @@ static inline void __attribute__((always_inline)) maxpool_chw(
         const int padding_left,
         const int padding_right,
         const int fixed_padding) {
-    MLI_OUT_PTR(io_T) __restrict out_ptr = out_ftrs + row_begin * out_width + clmn_begin;
 
-    for (int ch_idx = 0; ch_idx < channels_num; ch_idx++) {
+    MLI_ASSERT(in.col_mem_stride == 1 && out.col_mem_stride == 1);
+
+    MLI_OUT_PTR(io_T) __restrict out_ptr = out.ptr
+            + out.col_mem_stride * clmn_begin
+            + out.row_mem_stride * row_begin;
+
+    for (int ch_idx = 0; ch_idx < in.ch; ch_idx++) {
         for (int H_idx = row_begin; H_idx < row_end; H_idx++) {
             for (int W_idx = clmn_begin; W_idx < clmn_end; W_idx++) {
                 // Define area of input for maxpooling
@@ -280,9 +283,9 @@ static inline void __attribute__((always_inline)) maxpool_chw(
                 int top_comp = -MIN((int)(H_idx * stride_height) - padding_top, 0);
                 int left_comp = -MIN((int)(W_idx * stride_width) - padding_left, 0);
 
-                int right_comp = -MIN((int)in_width - ((int)(W_idx * stride_width) - padding_left + kernel_width), 0);
+                int right_comp = -MIN((int)in.width - ((int)(W_idx * stride_width) - padding_left + kernel_width), 0);
                 int bottom_comp =
-                        -MIN((int)in_height - ((int)(H_idx * stride_height) - padding_top + kernel_height), 0);
+                        -MIN((int)in.height - ((int)(H_idx * stride_height) - padding_top + kernel_height), 0);
 
                 if (fixed_padding) {
                     if (padding_left == 0) left_comp = 0;
@@ -294,38 +297,32 @@ static inline void __attribute__((always_inline)) maxpool_chw(
                 int rows = kernel_height - top_comp - bottom_comp;
                 int clmns = kernel_width - right_comp - left_comp;
 
-                const MLI_PTR(io_T) __restrict in_ptr =
-                        in_ftrs +                                                      // starting point
-                        in_width * in_height * ch_idx +                                // move to channels
-                        in_width * (H_idx * stride_height - padding_top + top_comp) +  // move to row
-                        (W_idx * stride_width) - padding_left + left_comp;             // move to column
+                const MLI_PTR(io_T) __restrict in_ptr = in.ptr
+                        + in.ch_mem_stride * ch_idx                                              // move to channels
+                        + in.row_mem_stride * (H_idx * stride_height - padding_top + top_comp)   // move to row
+                        + in.col_mem_stride * (W_idx * stride_width - padding_left + left_comp); // move to column
 
                 // Core Max
-                io_T max_val = reduce_max2D(in_ptr, clmns, rows, in_width, false);
+                io_T max_val = reduce_max2D(in_ptr, clmns, rows, in.row_mem_stride, false);
 
                 // Write result
                 *out_ptr++ = max_val;
                 MAXPOOL_DBG_PRINT(ch_idx, H_idx, W_idx, max_val);
             }
-            out_ptr += out_width + clmn_begin - clmn_end;
+            out_ptr += out.row_mem_stride - (clmn_end - clmn_begin);
         }
-        out_ptr += out_width * (out_height + row_begin - row_end);
+        out_ptr += out.ch_mem_stride - out.row_mem_stride * (row_end - row_begin);
     }
 }
 
 template <typename io_T>
 static inline void __attribute__((always_inline)) maxpool_chw_small(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        MLI_OUT_PTR(io_T) __restrict out_ftrs,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
         const int row_begin,
         const int row_end,
         const int clmn_begin,
         const int clmn_end,
-        const int channels_num,
-        const int in_width,
-        const int in_height,
-        const int out_width,
-        const int out_height,
         const int kernel_height,
         const int kernel_width,
         const int stride_height,
@@ -335,20 +332,25 @@ static inline void __attribute__((always_inline)) maxpool_chw_small(
         const int padding_left,
         const int padding_right,
         const int fixed_padding) {
-    MLI_ASSERT(kernel_width <= 3); // the code in this function assumes small kernel width.
-    MLI_OUT_PTR(io_T) __restrict out_ptr = out_ftrs + row_begin * out_width + clmn_begin;
 
-    for (int ch_idx = 0; ch_idx < channels_num; ch_idx++) {
+    MLI_ASSERT(in.col_mem_stride == 1 && out.col_mem_stride == 1);
+
+    MLI_ASSERT(kernel_width <= 3); // the code in this function assumes small kernel width.
+    MLI_OUT_PTR(io_T) __restrict out_ptr = out.ptr
+            + out.col_mem_stride * clmn_begin
+            + out.row_mem_stride * row_begin;
+
+    for (int ch_idx = 0; ch_idx < in.ch; ch_idx++) {
         for (int H_idx = row_begin; H_idx < row_end; H_idx++) {
             for (int W_idx = clmn_begin; W_idx < clmn_end; W_idx++) {
                 // Define area of input for maxpooling
                 // *_comp - compensation values for valid area defining
                 int top_comp = -MIN((int)(H_idx * stride_height) - padding_top, 0);
-				// because kernel width is max 3, left_comp and right_comp can be max 1
-				int left_comp = (W_idx * stride_width < padding_left) ? 1 : 0;
-				int right_comp = (in_width + padding_left - kernel_width < W_idx * stride_width) ? 1 : 0;
+                // because kernel width is max 3, left_comp and right_comp can be max 1
+                int left_comp = (W_idx * stride_width < padding_left) ? 1 : 0;
+                int right_comp = (in.width + padding_left - kernel_width < W_idx * stride_width) ? 1 : 0;
                 int bottom_comp =
-                        -MIN((int)in_height - ((int)(H_idx * stride_height) - padding_top + kernel_height), 0);
+                        -MIN((int)in.height - ((int)(H_idx * stride_height) - padding_top + kernel_height), 0);
 
                 if (fixed_padding) {
                     if (padding_left == 0) left_comp = 0;
@@ -360,38 +362,32 @@ static inline void __attribute__((always_inline)) maxpool_chw_small(
                 int rows = kernel_height - top_comp - bottom_comp;
                 int clmns = kernel_width - right_comp - left_comp;
 
-                const MLI_PTR(io_T) __restrict in_ptr =
-                        in_ftrs +                                                      // starting point
-                        in_width * in_height * ch_idx +                                // move to channels
-                        in_width * (H_idx * stride_height - padding_top + top_comp) +  // move to row
-                        (W_idx * stride_width) - padding_left + left_comp;             // move to column
+                const MLI_PTR(io_T) __restrict in_ptr = in.ptr
+                        + in.ch_mem_stride * ch_idx                                              // move to channels
+                        + in.row_mem_stride * (H_idx * stride_height - padding_top + top_comp)   // move to row
+                        + in.col_mem_stride * (W_idx * stride_width - padding_left + left_comp); // move to column
 
                 // Core Max
-                io_T max_val = reduce_max2D_small(in_ptr, clmns, rows, in_width, kernel_width);
+                io_T max_val = reduce_max2D(in_ptr, clmns, rows, in.row_mem_stride, kernel_width);
 
                 // Write result
                 *out_ptr++ = max_val;
                 MAXPOOL_DBG_PRINT(ch_idx, H_idx, W_idx, max_val);
             }
-            out_ptr += out_width + clmn_begin - clmn_end;
+            out_ptr += out.row_mem_stride - (clmn_end - clmn_begin);
         }
-        out_ptr += out_width * (out_height + row_begin - row_end);
+        out_ptr += out.ch_mem_stride - out.row_mem_stride * (row_end - row_begin);
     }
 }
 
 template <typename io_T>
 static inline void __attribute__((always_inline)) maxpool_chw_pad(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        MLI_OUT_PTR(io_T) __restrict out_ftrs,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
         const int row_beg,
         const int row_end,
         const int clmn_beg,
         const int clmn_end,
-        const int channels_num,
-        const int in_width,
-        const int in_height,
-        const int out_width,
-        const int out_height,
         const int kernel_height,
         const int kernel_width,
         const int stride_height,
@@ -403,15 +399,15 @@ static inline void __attribute__((always_inline)) maxpool_chw_pad(
         const int fixed_padding) {
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
-    if (in_height >= kernel_height && in_width >= kernel_width) {
+    if (in.height >= kernel_height && in.width >= kernel_width) {
         const int row_beg = CEIL_DIV(padding_top, stride_height);
-        const int row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+        const int row_end = out.height - CEIL_DIV(padding_bot, stride_height);
         const int clmn_beg = CEIL_DIV(padding_left, stride_width);
-        const int clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
+        const int clmn_end = out.width - CEIL_DIV(padding_right, stride_width);
 
         maxpool_chw_nopad(
-                in_ftrs, out_ftrs, row_beg, row_end, clmn_beg, clmn_end, channels_num, in_width, in_height, out_width,
-                out_height, kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_bot,
+                in, out, row_beg, row_end, clmn_beg, clmn_end,
+                kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_bot,
                 padding_left, padding_right, fixed_padding);
     }
     // Phase 2: Process border part with more complex algorithm
@@ -423,47 +419,42 @@ static inline void __attribute__((always_inline)) maxpool_chw_pad(
         areas[areas_num].row_beg = 0;
         areas[areas_num].row_end = CEIL_DIV (padding_top, stride_height);
         areas[areas_num].clmn_beg = 0;
-        areas[areas_num++].clmn_end = out_width;
+        areas[areas_num++].clmn_end = out.width;
     }
     if (padding_bot) {
-        areas[areas_num].row_beg = out_height - CEIL_DIV (padding_bot, stride_height);
-        areas[areas_num].row_end = out_height;
+        areas[areas_num].row_beg = out.height - CEIL_DIV (padding_bot, stride_height);
+        areas[areas_num].row_end = out.height;
         areas[areas_num].clmn_beg = 0;
-        areas[areas_num++].clmn_end = out_width;
+        areas[areas_num++].clmn_end = out.width;
     }
     if (padding_left) {
         areas[areas_num].row_beg = CEIL_DIV (padding_top, stride_height);
-        areas[areas_num].row_end = out_height - CEIL_DIV (padding_bot, stride_height);
+        areas[areas_num].row_end = out.height - CEIL_DIV (padding_bot, stride_height);
         areas[areas_num].clmn_beg = 0;
         areas[areas_num++].clmn_end = CEIL_DIV (padding_left, stride_width);
     }
     if (padding_right) {
         areas[areas_num].row_beg = CEIL_DIV (padding_top, stride_height);
-        areas[areas_num].row_end = out_height - CEIL_DIV (padding_bot, stride_height);
-        areas[areas_num].clmn_beg = out_width - CEIL_DIV (padding_right, stride_width);
-        areas[areas_num++].clmn_end = out_width;
+        areas[areas_num].row_end = out.height - CEIL_DIV (padding_bot, stride_height);
+        areas[areas_num].clmn_beg = out.width - CEIL_DIV (padding_right, stride_width);
+        areas[areas_num++].clmn_end = out.width;
     }
     for (int i = 0; i < areas_num; i++) {
         maxpool_chw(
-                in_ftrs, out_ftrs, areas[i].row_beg, areas[i].row_end, areas[i].clmn_beg, areas[i].clmn_end, channels_num, in_width, in_height, out_width,
-                out_height, kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_bot,
+                in, out, areas[i].row_beg, areas[i].row_end, areas[i].clmn_beg, areas[i].clmn_end,
+                kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_bot,
                 padding_left, padding_right, fixed_padding);
     }
 }
 
 template <typename io_T>
 static inline void __attribute__((always_inline)) maxpool_chw_krnpad_small(
-        const MLI_PTR(io_T) __restrict in_ftrs,
-        MLI_OUT_PTR(io_T) __restrict out_ftrs,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
         const int row_beg,
         const int row_end,
         const int clmn_beg,
         const int clmn_end,
-        const int channels_num,
-        const int in_width,
-        const int in_height,
-        const int out_width,
-        const int out_height,
         const int kernel_height,
         const int kernel_width,
         const int stride_height,
@@ -473,17 +464,20 @@ static inline void __attribute__((always_inline)) maxpool_chw_krnpad_small(
         const int padding_left,
         const int padding_right,
         const int fixed_padding) {
+
+    MLI_ASSERT(in.col_mem_stride == 1 && out.col_mem_stride == 1);
+
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
-    if (in_height >= kernel_height && in_width >= kernel_width) {
+    if (in.height >= kernel_height && in.width >= kernel_width) {
         const int row_beg = CEIL_DIV(padding_top, stride_height);
-        const int row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+        const int row_end = out.height - CEIL_DIV(padding_bot, stride_height);
         const int clmn_beg = CEIL_DIV(padding_left, stride_width);
-        const int clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
+        const int clmn_end = out.width - CEIL_DIV(padding_right, stride_width);
 
         maxpool_chw_nopad(
-                in_ftrs, out_ftrs, row_beg, row_end, clmn_beg, clmn_end, channels_num, in_width, in_height, out_width,
-                out_height, kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_bot,
+                in, out, row_beg, row_end, clmn_beg, clmn_end,
+                kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_bot,
                 padding_left, padding_right, fixed_padding);
     }
     // Phase 2: Process border part with more complex algorithm
@@ -495,30 +489,30 @@ static inline void __attribute__((always_inline)) maxpool_chw_krnpad_small(
         areas[areas_num].row_beg = 0;
         areas[areas_num].row_end = CEIL_DIV (padding_top, stride_height);
         areas[areas_num].clmn_beg = 0;
-        areas[areas_num++].clmn_end = out_width;
+        areas[areas_num++].clmn_end = out.width;
     }
     if (padding_bot) {
-        areas[areas_num].row_beg = out_height - CEIL_DIV (padding_bot, stride_height);
-        areas[areas_num].row_end = out_height;
+        areas[areas_num].row_beg = out.height - CEIL_DIV (padding_bot, stride_height);
+        areas[areas_num].row_end = out.height;
         areas[areas_num].clmn_beg = 0;
-        areas[areas_num++].clmn_end = out_width;
+        areas[areas_num++].clmn_end = out.width;
     }
     if (padding_left) {
         areas[areas_num].row_beg = CEIL_DIV (padding_top, stride_height);
-        areas[areas_num].row_end = out_height - CEIL_DIV (padding_bot, stride_height);
+        areas[areas_num].row_end = out.height - CEIL_DIV (padding_bot, stride_height);
         areas[areas_num].clmn_beg = 0;
         areas[areas_num++].clmn_end = CEIL_DIV (padding_left, stride_width);
     }
     if (padding_right) {
         areas[areas_num].row_beg = CEIL_DIV (padding_top, stride_height);
-        areas[areas_num].row_end = out_height - CEIL_DIV (padding_bot, stride_height);
-        areas[areas_num].clmn_beg = out_width - CEIL_DIV (padding_right, stride_width);
-        areas[areas_num++].clmn_end = out_width;
+        areas[areas_num].row_end = out.height - CEIL_DIV (padding_bot, stride_height);
+        areas[areas_num].clmn_beg = out.width - CEIL_DIV (padding_right, stride_width);
+        areas[areas_num++].clmn_end = out.width;
     }
     for (int i = 0; i < areas_num; i++) {
         maxpool_chw_small(
-                in_ftrs, out_ftrs, areas[i].row_beg, areas[i].row_end, areas[i].clmn_beg, areas[i].clmn_end, channels_num, in_width, in_height, out_width,
-                out_height, kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_bot,
+                in, out, areas[i].row_beg, areas[i].row_end, areas[i].clmn_beg, areas[i].clmn_end,
+                kernel_height, kernel_width, stride_height, stride_width, padding_top, padding_bot,
                 padding_left, padding_right, fixed_padding);
     }
 }

--- a/lib/src/kernels/pooling/mli_krn_maxpool_chw_fx16.cc
+++ b/lib/src/kernels/pooling/mli_krn_maxpool_chw_fx16.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_str1_nopad(const mli_tensor * in, const
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 1
     MLI_CHECK_AND_FIX(stride_width, 1);
@@ -63,20 +67,19 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_str1_nopad(const mli_tensor * in, const
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -86,23 +89,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_str1_nopad(const mli_tensor * in, const
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -119,9 +112,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -141,20 +138,19 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_nopad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -164,23 +160,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -197,9 +183,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -219,20 +209,19 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3_nopad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -242,23 +231,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -275,9 +254,13 @@ mli_status mli_krn_maxpool_chw_fx16_k4x4_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -297,20 +280,19 @@ mli_status mli_krn_maxpool_chw_fx16_k4x4_nopad(const mli_tensor * in, const mli_
 #if 4
     MLI_CHECK_AND_FIX(kernel_height, 4);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -320,23 +302,13 @@ mli_status mli_krn_maxpool_chw_fx16_k4x4_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -353,9 +325,13 @@ mli_status mli_krn_maxpool_chw_fx16_k5x5_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -375,20 +351,19 @@ mli_status mli_krn_maxpool_chw_fx16_k5x5_nopad(const mli_tensor * in, const mli_
 #if 5
     MLI_CHECK_AND_FIX(kernel_height, 5);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -398,23 +373,13 @@ mli_status mli_krn_maxpool_chw_fx16_k5x5_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -431,9 +396,13 @@ mli_status mli_krn_maxpool_chw_fx16_k6x6_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -453,20 +422,19 @@ mli_status mli_krn_maxpool_chw_fx16_k6x6_nopad(const mli_tensor * in, const mli_
 #if 6
     MLI_CHECK_AND_FIX(kernel_height, 6);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -476,23 +444,13 @@ mli_status mli_krn_maxpool_chw_fx16_k6x6_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -509,9 +467,13 @@ mli_status mli_krn_maxpool_chw_fx16_k7x7_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -531,20 +493,19 @@ mli_status mli_krn_maxpool_chw_fx16_k7x7_nopad(const mli_tensor * in, const mli_
 #if 7
     MLI_CHECK_AND_FIX(kernel_height, 7);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -554,23 +515,13 @@ mli_status mli_krn_maxpool_chw_fx16_k7x7_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -587,9 +538,13 @@ mli_status mli_krn_maxpool_chw_fx16_k8x8_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -609,20 +564,19 @@ mli_status mli_krn_maxpool_chw_fx16_k8x8_nopad(const mli_tensor * in, const mli_
 #if 8
     MLI_CHECK_AND_FIX(kernel_height, 8);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -632,23 +586,13 @@ mli_status mli_krn_maxpool_chw_fx16_k8x8_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -665,9 +609,13 @@ mli_status mli_krn_maxpool_chw_fx16_k9x9_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -687,20 +635,19 @@ mli_status mli_krn_maxpool_chw_fx16_k9x9_nopad(const mli_tensor * in, const mli_
 #if 9
     MLI_CHECK_AND_FIX(kernel_height, 9);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -710,23 +657,13 @@ mli_status mli_krn_maxpool_chw_fx16_k9x9_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -743,9 +680,13 @@ mli_status mli_krn_maxpool_chw_fx16_k10x10_nopad(const mli_tensor * in, const ml
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -765,20 +706,19 @@ mli_status mli_krn_maxpool_chw_fx16_k10x10_nopad(const mli_tensor * in, const ml
 #if 10
     MLI_CHECK_AND_FIX(kernel_height, 10);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -788,23 +728,13 @@ mli_status mli_krn_maxpool_chw_fx16_k10x10_nopad(const mli_tensor * in, const ml
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -821,9 +751,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1x2_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -843,20 +777,19 @@ mli_status mli_krn_maxpool_chw_fx16_k1x2_nopad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -866,23 +799,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1x2_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -899,9 +822,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1x3_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -921,20 +848,19 @@ mli_status mli_krn_maxpool_chw_fx16_k1x3_nopad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -944,23 +870,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1x3_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -977,9 +893,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x1_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -999,20 +919,19 @@ mli_status mli_krn_maxpool_chw_fx16_k2x1_nopad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1022,23 +941,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x1_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1055,9 +964,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x1_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1077,20 +990,19 @@ mli_status mli_krn_maxpool_chw_fx16_k3x1_nopad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1100,23 +1012,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x1_nopad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1133,9 +1035,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1155,20 +1061,19 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_krnpad(const mli_tensor * in, const mli
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1178,23 +1083,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_krnpad_small(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1211,9 +1106,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1233,20 +1132,19 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3_krnpad(const mli_tensor * in, const mli
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1256,23 +1154,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_krnpad_small(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1289,9 +1177,13 @@ mli_status mli_krn_maxpool_chw_fx16_k4x4_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1311,20 +1203,19 @@ mli_status mli_krn_maxpool_chw_fx16_k4x4_krnpad(const mli_tensor * in, const mli
 #if 4
     MLI_CHECK_AND_FIX(kernel_height, 4);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1334,23 +1225,13 @@ mli_status mli_krn_maxpool_chw_fx16_k4x4_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1367,9 +1248,13 @@ mli_status mli_krn_maxpool_chw_fx16_k5x5_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1389,20 +1274,19 @@ mli_status mli_krn_maxpool_chw_fx16_k5x5_krnpad(const mli_tensor * in, const mli
 #if 5
     MLI_CHECK_AND_FIX(kernel_height, 5);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1412,23 +1296,13 @@ mli_status mli_krn_maxpool_chw_fx16_k5x5_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1445,9 +1319,13 @@ mli_status mli_krn_maxpool_chw_fx16_k6x6_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1467,20 +1345,19 @@ mli_status mli_krn_maxpool_chw_fx16_k6x6_krnpad(const mli_tensor * in, const mli
 #if 6
     MLI_CHECK_AND_FIX(kernel_height, 6);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1490,23 +1367,13 @@ mli_status mli_krn_maxpool_chw_fx16_k6x6_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1523,9 +1390,13 @@ mli_status mli_krn_maxpool_chw_fx16_k7x7_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1545,20 +1416,19 @@ mli_status mli_krn_maxpool_chw_fx16_k7x7_krnpad(const mli_tensor * in, const mli
 #if 7
     MLI_CHECK_AND_FIX(kernel_height, 7);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1568,23 +1438,13 @@ mli_status mli_krn_maxpool_chw_fx16_k7x7_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1601,9 +1461,13 @@ mli_status mli_krn_maxpool_chw_fx16_k8x8_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1623,20 +1487,19 @@ mli_status mli_krn_maxpool_chw_fx16_k8x8_krnpad(const mli_tensor * in, const mli
 #if 8
     MLI_CHECK_AND_FIX(kernel_height, 8);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1646,23 +1509,13 @@ mli_status mli_krn_maxpool_chw_fx16_k8x8_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1679,9 +1532,13 @@ mli_status mli_krn_maxpool_chw_fx16_k9x9_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1701,20 +1558,19 @@ mli_status mli_krn_maxpool_chw_fx16_k9x9_krnpad(const mli_tensor * in, const mli
 #if 9
     MLI_CHECK_AND_FIX(kernel_height, 9);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1724,23 +1580,13 @@ mli_status mli_krn_maxpool_chw_fx16_k9x9_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1757,9 +1603,13 @@ mli_status mli_krn_maxpool_chw_fx16_k10x10_krnpad(const mli_tensor * in, const m
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1779,20 +1629,19 @@ mli_status mli_krn_maxpool_chw_fx16_k10x10_krnpad(const mli_tensor * in, const m
 #if 10
     MLI_CHECK_AND_FIX(kernel_height, 10);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1802,23 +1651,13 @@ mli_status mli_krn_maxpool_chw_fx16_k10x10_krnpad(const mli_tensor * in, const m
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1835,9 +1674,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1x2_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1857,20 +1700,19 @@ mli_status mli_krn_maxpool_chw_fx16_k1x2_krnpad(const mli_tensor * in, const mli
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1880,23 +1722,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1x2_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1913,9 +1745,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1x3_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1935,20 +1771,19 @@ mli_status mli_krn_maxpool_chw_fx16_k1x3_krnpad(const mli_tensor * in, const mli
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1958,23 +1793,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1x3_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1991,9 +1816,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x1_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2013,20 +1842,19 @@ mli_status mli_krn_maxpool_chw_fx16_k2x1_krnpad(const mli_tensor * in, const mli
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2036,23 +1864,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x1_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2069,9 +1887,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x1_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2091,20 +1913,19 @@ mli_status mli_krn_maxpool_chw_fx16_k3x1_krnpad(const mli_tensor * in, const mli
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2114,23 +1935,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x1_krnpad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2147,9 +1958,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1xn(const mli_tensor * in, const mli_pool_c
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2169,20 +1984,19 @@ mli_status mli_krn_maxpool_chw_fx16_k1xn(const mli_tensor * in, const mli_pool_c
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2192,23 +2006,13 @@ mli_status mli_krn_maxpool_chw_fx16_k1xn(const mli_tensor * in, const mli_pool_c
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2225,9 +2029,13 @@ mli_status mli_krn_maxpool_chw_fx16_knx1(const mli_tensor * in, const mli_pool_c
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2247,20 +2055,19 @@ mli_status mli_krn_maxpool_chw_fx16_knx1(const mli_tensor * in, const mli_pool_c
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2270,23 +2077,13 @@ mli_status mli_krn_maxpool_chw_fx16_knx1(const mli_tensor * in, const mli_pool_c
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2303,9 +2100,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2(const mli_tensor * in, const mli_pool_c
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2325,20 +2126,19 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2(const mli_tensor * in, const mli_pool_c
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2348,23 +2148,13 @@ mli_status mli_krn_maxpool_chw_fx16_k2x2(const mli_tensor * in, const mli_pool_c
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2381,9 +2171,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3(const mli_tensor * in, const mli_pool_c
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2403,20 +2197,19 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3(const mli_tensor * in, const mli_pool_c
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2426,23 +2219,13 @@ mli_status mli_krn_maxpool_chw_fx16_k3x3(const mli_tensor * in, const mli_pool_c
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2459,9 +2242,13 @@ mli_status mli_krn_maxpool_chw_fx16_generic(const mli_tensor * in, const mli_poo
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2481,20 +2268,19 @@ mli_status mli_krn_maxpool_chw_fx16_generic(const mli_tensor * in, const mli_poo
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2504,23 +2290,13 @@ mli_status mli_krn_maxpool_chw_fx16_generic(const mli_tensor * in, const mli_poo
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_maxpool_chw_fx8.cc
+++ b/lib/src/kernels/pooling/mli_krn_maxpool_chw_fx8.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_str1_nopad(const mli_tensor * in, const 
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 1
     MLI_CHECK_AND_FIX(stride_width, 1);
@@ -63,20 +67,19 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_str1_nopad(const mli_tensor * in, const 
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -86,23 +89,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_str1_nopad(const mli_tensor * in, const 
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -119,9 +112,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -141,20 +138,19 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -164,23 +160,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -197,9 +183,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -219,20 +209,19 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -242,23 +231,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -275,9 +254,13 @@ mli_status mli_krn_maxpool_chw_fx8_k4x4_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -297,20 +280,19 @@ mli_status mli_krn_maxpool_chw_fx8_k4x4_nopad(const mli_tensor * in, const mli_p
 #if 4
     MLI_CHECK_AND_FIX(kernel_height, 4);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -320,23 +302,13 @@ mli_status mli_krn_maxpool_chw_fx8_k4x4_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -353,9 +325,13 @@ mli_status mli_krn_maxpool_chw_fx8_k5x5_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -375,20 +351,19 @@ mli_status mli_krn_maxpool_chw_fx8_k5x5_nopad(const mli_tensor * in, const mli_p
 #if 5
     MLI_CHECK_AND_FIX(kernel_height, 5);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -398,23 +373,13 @@ mli_status mli_krn_maxpool_chw_fx8_k5x5_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -431,9 +396,13 @@ mli_status mli_krn_maxpool_chw_fx8_k6x6_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -453,20 +422,19 @@ mli_status mli_krn_maxpool_chw_fx8_k6x6_nopad(const mli_tensor * in, const mli_p
 #if 6
     MLI_CHECK_AND_FIX(kernel_height, 6);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -476,23 +444,13 @@ mli_status mli_krn_maxpool_chw_fx8_k6x6_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -509,9 +467,13 @@ mli_status mli_krn_maxpool_chw_fx8_k7x7_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -531,20 +493,19 @@ mli_status mli_krn_maxpool_chw_fx8_k7x7_nopad(const mli_tensor * in, const mli_p
 #if 7
     MLI_CHECK_AND_FIX(kernel_height, 7);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -554,23 +515,13 @@ mli_status mli_krn_maxpool_chw_fx8_k7x7_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -587,9 +538,13 @@ mli_status mli_krn_maxpool_chw_fx8_k8x8_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -609,20 +564,19 @@ mli_status mli_krn_maxpool_chw_fx8_k8x8_nopad(const mli_tensor * in, const mli_p
 #if 8
     MLI_CHECK_AND_FIX(kernel_height, 8);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -632,23 +586,13 @@ mli_status mli_krn_maxpool_chw_fx8_k8x8_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -665,9 +609,13 @@ mli_status mli_krn_maxpool_chw_fx8_k9x9_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -687,20 +635,19 @@ mli_status mli_krn_maxpool_chw_fx8_k9x9_nopad(const mli_tensor * in, const mli_p
 #if 9
     MLI_CHECK_AND_FIX(kernel_height, 9);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -710,23 +657,13 @@ mli_status mli_krn_maxpool_chw_fx8_k9x9_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -743,9 +680,13 @@ mli_status mli_krn_maxpool_chw_fx8_k10x10_nopad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -765,20 +706,19 @@ mli_status mli_krn_maxpool_chw_fx8_k10x10_nopad(const mli_tensor * in, const mli
 #if 10
     MLI_CHECK_AND_FIX(kernel_height, 10);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -788,23 +728,13 @@ mli_status mli_krn_maxpool_chw_fx8_k10x10_nopad(const mli_tensor * in, const mli
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -821,9 +751,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1x2_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -843,20 +777,19 @@ mli_status mli_krn_maxpool_chw_fx8_k1x2_nopad(const mli_tensor * in, const mli_p
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -866,23 +799,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1x2_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -899,9 +822,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1x3_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -921,20 +848,19 @@ mli_status mli_krn_maxpool_chw_fx8_k1x3_nopad(const mli_tensor * in, const mli_p
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -944,23 +870,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1x3_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -977,9 +893,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x1_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -999,20 +919,19 @@ mli_status mli_krn_maxpool_chw_fx8_k2x1_nopad(const mli_tensor * in, const mli_p
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1022,23 +941,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x1_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1055,9 +964,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x1_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1077,20 +990,19 @@ mli_status mli_krn_maxpool_chw_fx8_k3x1_nopad(const mli_tensor * in, const mli_p
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1100,23 +1012,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x1_nopad(const mli_tensor * in, const mli_p
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_nopad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         1);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1133,9 +1035,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1155,20 +1061,19 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1178,23 +1083,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_krnpad_small(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1211,9 +1106,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1233,20 +1132,19 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1256,23 +1154,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_krnpad_small(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1289,9 +1177,13 @@ mli_status mli_krn_maxpool_chw_fx8_k4x4_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1311,20 +1203,19 @@ mli_status mli_krn_maxpool_chw_fx8_k4x4_krnpad(const mli_tensor * in, const mli_
 #if 4
     MLI_CHECK_AND_FIX(kernel_height, 4);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1334,23 +1225,13 @@ mli_status mli_krn_maxpool_chw_fx8_k4x4_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1367,9 +1248,13 @@ mli_status mli_krn_maxpool_chw_fx8_k5x5_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1389,20 +1274,19 @@ mli_status mli_krn_maxpool_chw_fx8_k5x5_krnpad(const mli_tensor * in, const mli_
 #if 5
     MLI_CHECK_AND_FIX(kernel_height, 5);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1412,23 +1296,13 @@ mli_status mli_krn_maxpool_chw_fx8_k5x5_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1445,9 +1319,13 @@ mli_status mli_krn_maxpool_chw_fx8_k6x6_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1467,20 +1345,19 @@ mli_status mli_krn_maxpool_chw_fx8_k6x6_krnpad(const mli_tensor * in, const mli_
 #if 6
     MLI_CHECK_AND_FIX(kernel_height, 6);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1490,23 +1367,13 @@ mli_status mli_krn_maxpool_chw_fx8_k6x6_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1523,9 +1390,13 @@ mli_status mli_krn_maxpool_chw_fx8_k7x7_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1545,20 +1416,19 @@ mli_status mli_krn_maxpool_chw_fx8_k7x7_krnpad(const mli_tensor * in, const mli_
 #if 7
     MLI_CHECK_AND_FIX(kernel_height, 7);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1568,23 +1438,13 @@ mli_status mli_krn_maxpool_chw_fx8_k7x7_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1601,9 +1461,13 @@ mli_status mli_krn_maxpool_chw_fx8_k8x8_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1623,20 +1487,19 @@ mli_status mli_krn_maxpool_chw_fx8_k8x8_krnpad(const mli_tensor * in, const mli_
 #if 8
     MLI_CHECK_AND_FIX(kernel_height, 8);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1646,23 +1509,13 @@ mli_status mli_krn_maxpool_chw_fx8_k8x8_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1679,9 +1532,13 @@ mli_status mli_krn_maxpool_chw_fx8_k9x9_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1701,20 +1558,19 @@ mli_status mli_krn_maxpool_chw_fx8_k9x9_krnpad(const mli_tensor * in, const mli_
 #if 9
     MLI_CHECK_AND_FIX(kernel_height, 9);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1724,23 +1580,13 @@ mli_status mli_krn_maxpool_chw_fx8_k9x9_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1757,9 +1603,13 @@ mli_status mli_krn_maxpool_chw_fx8_k10x10_krnpad(const mli_tensor * in, const ml
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1779,20 +1629,19 @@ mli_status mli_krn_maxpool_chw_fx8_k10x10_krnpad(const mli_tensor * in, const ml
 #if 10
     MLI_CHECK_AND_FIX(kernel_height, 10);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1802,23 +1651,13 @@ mli_status mli_krn_maxpool_chw_fx8_k10x10_krnpad(const mli_tensor * in, const ml
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1835,9 +1674,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1x2_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1857,20 +1700,19 @@ mli_status mli_krn_maxpool_chw_fx8_k1x2_krnpad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1880,23 +1722,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1x2_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1913,9 +1745,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1x3_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -1935,20 +1771,19 @@ mli_status mli_krn_maxpool_chw_fx8_k1x3_krnpad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -1958,23 +1793,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1x3_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -1991,9 +1816,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x1_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2013,20 +1842,19 @@ mli_status mli_krn_maxpool_chw_fx8_k2x1_krnpad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2036,23 +1864,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x1_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2069,9 +1887,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x1_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2091,20 +1913,19 @@ mli_status mli_krn_maxpool_chw_fx8_k3x1_krnpad(const mli_tensor * in, const mli_
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2114,23 +1935,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x1_krnpad(const mli_tensor * in, const mli_
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2147,9 +1958,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1xn(const mli_tensor * in, const mli_pool_cf
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2169,20 +1984,19 @@ mli_status mli_krn_maxpool_chw_fx8_k1xn(const mli_tensor * in, const mli_pool_cf
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2192,23 +2006,13 @@ mli_status mli_krn_maxpool_chw_fx8_k1xn(const mli_tensor * in, const mli_pool_cf
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2225,9 +2029,13 @@ mli_status mli_krn_maxpool_chw_fx8_knx1(const mli_tensor * in, const mli_pool_cf
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2247,20 +2055,19 @@ mli_status mli_krn_maxpool_chw_fx8_knx1(const mli_tensor * in, const mli_pool_cf
 #if 1
     MLI_CHECK_AND_FIX(kernel_height, 1);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2270,23 +2077,13 @@ mli_status mli_krn_maxpool_chw_fx8_knx1(const mli_tensor * in, const mli_pool_cf
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2303,9 +2100,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2(const mli_tensor * in, const mli_pool_cf
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2325,20 +2126,19 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2(const mli_tensor * in, const mli_pool_cf
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2348,23 +2148,13 @@ mli_status mli_krn_maxpool_chw_fx8_k2x2(const mli_tensor * in, const mli_pool_cf
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2381,9 +2171,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3(const mli_tensor * in, const mli_pool_cf
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2403,20 +2197,19 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3(const mli_tensor * in, const mli_pool_cf
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2426,23 +2219,13 @@ mli_status mli_krn_maxpool_chw_fx8_k3x3(const mli_tensor * in, const mli_pool_cf
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }
@@ -2459,9 +2242,13 @@ mli_status mli_krn_maxpool_chw_fx8_generic(const mli_tensor * in, const mli_pool
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_CHW];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_chw<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -2481,20 +2268,19 @@ mli_status mli_krn_maxpool_chw_fx8_generic(const mli_tensor * in, const mli_pool
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_CHW];
-    const int32_t in_width = in->shape[FMAP_W_DIM_CHW];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_C_DIM_CHW] = in_prv.ch;
+    out->shape[FMAP_H_DIM_CHW] = out_height;
+    out->shape[FMAP_W_DIM_CHW] = out_width;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_chw<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -2504,23 +2290,13 @@ mli_status mli_krn_maxpool_chw_fx8_generic(const mli_tensor * in, const mli_pool
     mli_prv_fx_init_dsp_ctrl();
 
     maxpool_chw_pad(
-        in_ftrs, out_ftrs,
+        in_prv, out_prv,
         row_beg, row_end,
         clmn_beg, clmn_end,
-        channels_num, in_width, in_height,
-        out_width, out_height,
         kernel_height, kernel_width,
         stride_height, stride_width,
         padding_top, padding_bot, padding_left, padding_right,
         0);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_C_DIM_CHW] = channels_num;
-    out->shape[FMAP_H_DIM_CHW] = out_height;
-    out->shape[FMAP_W_DIM_CHW] = out_width;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_maxpool_hwc.h
+++ b/lib/src/kernels/pooling/mli_krn_maxpool_hwc.h
@@ -49,18 +49,14 @@ static inline io_T __attribute__((always_inline)) reduce_max2D_hwc(
         const MLI_PTR(io_T) in,
         const int width,
         const int height,
-        const int channels,
-        const int in_row_step,
+        const int col_mem_stride,
+        const int row_mem_stride,
         const bool fixed_size) {
-    int row = 0;
-    int clmn = 0;
-    io_T cur_max = in[channels * clmn++];
-    for (; row < height; row++) {
-        for (; clmn < width; clmn++) {
-            cur_max = MAX(cur_max, in[clmn * channels]);
+    io_T cur_max = in[0];
+    for (int row = 0; row < height; row++) {
+        for (int clmn = 0; clmn < width; clmn++) {
+            cur_max = MAX(cur_max, in[(row_mem_stride * row) + (col_mem_stride * clmn)]);
         }
-        clmn = 0;
-        in += in_row_step * channels;
     }
     return cur_max;
 }
@@ -71,16 +67,18 @@ static inline v2q15_t reduce_max2D_hwc_v(
         const int width,
         const int height,
         const int channels,
-        const int in_row_step,
+        const int col_mem_stride,
+        const int row_mem_stride,
         const bool fixed_size) {
+
     v2q15_t cur_max = mli_prv_load_2_samples(in);
     if (width == 1){
         for (int row = 0; row < height; row++) {
-            cur_max = fx_max_v2q15(cur_max, mli_prv_load_2_samples(&in[in_row_step * channels * row]));
+            cur_max = fx_max_v2q15(cur_max, mli_prv_load_2_samples(&in[row*row_mem_stride]));
         }
     } else if (height == 1){
         for (int clmn = 0; clmn < width; clmn++) {
-            cur_max = fx_max_v2q15(cur_max, mli_prv_load_2_samples(&in[clmn * channels]));
+            cur_max = fx_max_v2q15(cur_max, mli_prv_load_2_samples(&in[clmn*col_mem_stride]));
         }
     } else {
         if (fixed_size && height <= REDUCE_MAX2D_UNROLL_FACTOR_FOR_HEIGHT && height <= REDUCE_MAX2D_UNROLL_FACTOR_FOR_WIDTH) {
@@ -88,16 +86,16 @@ static inline v2q15_t reduce_max2D_hwc_v(
             for (int row = 0; row < height; row++) {
 #pragma clang loop unroll(full)
                 for (int clmn = 0; clmn < width; clmn++) {
-                    cur_max = fx_max_v2q15(cur_max, mli_prv_load_2_samples(&in[clmn * channels]));
+                    cur_max = fx_max_v2q15(cur_max, mli_prv_load_2_samples(
+                        &in[(row * row_mem_stride) + (clmn * col_mem_stride)]));
                 }
-                in += in_row_step * channels;
             }
         } else {
             for (int row = 0; row < height; row++) {
                 for (int clmn = 0; clmn < width; clmn++) {
-                    cur_max = fx_max_v2q15(cur_max, mli_prv_load_2_samples(&in[clmn * channels]));
+                    cur_max = fx_max_v2q15(cur_max, mli_prv_load_2_samples(
+                        &in[(row * row_mem_stride) +  (clmn * col_mem_stride)]));
                 }
-                in += in_row_step * channels;
             }
         }
     }
@@ -106,104 +104,98 @@ static inline v2q15_t reduce_max2D_hwc_v(
 
 template <typename io_T>
 static inline void __attribute__((always_inline)) maxpool_hwc_nopad(
-    int row_beg,
-    int row_end, 
-    int clmn_beg,
-    int clmn_end,
-    int stride_width,
-    int stride_height,
-    int padding_top,
-    int padding_bot,
-    int padding_left,
-    int padding_right,
-    const MLI_PTR(io_T) in_ftrs,
-    MLI_OUT_PTR(io_T) out_ftrs,
-    int channels_num,
-    int kernel_height,
-    int kernel_width,
-    int in_height,
-    int in_width,
-    int out_width,
-    int out_height) {
+        int row_beg,
+        int row_end,
+        int clmn_beg,
+        int clmn_end,
+        int stride_width,
+        int stride_height,
+        int padding_top,
+        int padding_bot,
+        int padding_left,
+        int padding_right,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
+        int kernel_height,
+        int kernel_width) {
 
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
-    if (in_height >= kernel_height && in_width >= kernel_width) {
-        for (int ch_idx = 0; ch_idx < channels_num - (channels_num & 1); ch_idx+=2) {
+    if (in.height >= kernel_height && in.width >= kernel_width) {
+        for (int ch_idx = 0; ch_idx < in.ch - (in.ch & 1); ch_idx+=2) {
             for (int H_idx = row_beg; H_idx < row_end; H_idx++) {
                 for (int W_idx = clmn_beg; W_idx < clmn_end; W_idx++) {
                     // Define area of input and filter for convolution
-                    const MLI_PTR(io_T) in_ptr =
-                            in_ftrs +                                                          // starting point
-                            channels_num * in_width * (H_idx * stride_height - padding_top) +  // move to row
-                            channels_num * (W_idx * stride_width - padding_left) +             // move to column
-                            ch_idx;                                                            // move to channel
+                    const MLI_PTR(io_T) in_ptr = in.ptr
+                            + in.row_mem_stride * (H_idx * stride_height - padding_top) // move to row
+                            + in.col_mem_stride * (W_idx * stride_width - padding_left) // move to column
+                            + ch_idx;                                                   // move to channel
 
                     // Core Max
-                    v2q15_t max_val = reduce_max2D_hwc_v<io_T>(in_ptr, kernel_width, kernel_height, channels_num, in_width, true);
+                    v2q15_t max_val = reduce_max2D_hwc_v<io_T>(in_ptr, kernel_width, kernel_height, in.ch,
+                        in.col_mem_stride, in.row_mem_stride, true);
                     // Write results
-                    mli_prv_store_2_samples(&out_ftrs[ch_idx + (H_idx * out_width + W_idx) * channels_num], max_val);
+                    mli_prv_store_2_samples(&out.ptr[
+                            out.row_mem_stride * H_idx +
+                            out.col_mem_stride * W_idx +
+                            ch_idx], max_val);
                 }
             }
         }
-        if (channels_num & 1){
+        if (in.ch & 1) {
             for (int H_idx = row_beg; H_idx < row_end; H_idx++) {
                 for (int W_idx = clmn_beg; W_idx < clmn_end; W_idx++) {
                     // Define area of input and filter for convolution
-                    const MLI_PTR(io_T) in_ptr =
-                            in_ftrs +                                                          // starting point
-                            channels_num * in_width * (H_idx * stride_height - padding_top) +  // move to row
-                            channels_num * (W_idx * stride_width - padding_left) +             // move to column
-                            channels_num - 1;                                                  // move to channel
+                    const MLI_PTR(io_T) in_ptr = in.ptr
+                            + in.row_mem_stride * (H_idx * stride_height - padding_top) // move to row
+                            + in.col_mem_stride * (W_idx * stride_width - padding_left) // move to column
+                            + in.ch - 1;                                                // move to channel
 
                     // Core Max
-                    io_T max_val = reduce_max2D_hwc<io_T>(in_ptr, kernel_width, kernel_height, channels_num, in_width, true);
+                    io_T max_val = reduce_max2D_hwc<io_T>(in_ptr, kernel_width, kernel_height,
+                        in.col_mem_stride, in.row_mem_stride, true);
 
                     // Write results
-                    out_ftrs[channels_num - 1 + (H_idx * out_width + W_idx) * channels_num] = max_val;
+                    out.ptr[out.row_mem_stride * H_idx
+                            + out.col_mem_stride * W_idx
+                            + out.ch - 1] = max_val;
                 }
             }
         }
-    }   
+    }
 }
 
 template <typename io_T>
 static inline void __attribute__((always_inline)) maxpool_hwc_pad(
-    int row_beg,
-    int row_end, 
-    int clmn_beg,
-    int clmn_end,
-    int stride_width,
-    int stride_height,
-    int padding_top,
-    int padding_bot,
-    int padding_left,
-    int padding_right,
-    const MLI_PTR(io_T) in_ftrs,
-    MLI_OUT_PTR(io_T) out_ftrs,
-    int channels_num,
-    int kernel_height,
-    int kernel_width,
-    int in_height,
-    int in_width,
-    int out_width,
-    int out_height) {
+        int row_beg,
+        int row_end,
+        int clmn_beg,
+        int clmn_end,
+        int stride_width,
+        int stride_height,
+        int padding_top,
+        int padding_bot,
+        int padding_left,
+        int padding_right,
+        const tensor_private_t<MLI_PTR(io_T)> &in,
+        const tensor_private_t<MLI_OUT_PTR(io_T)> &out,
+        int kernel_height,
+        int kernel_width) {
 
     // Phase 1: Process central part (without border effects - padding free)
     //=======================================================================
     row_beg = CEIL_DIV(padding_top, stride_height);
-    row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+    row_end = out.height - CEIL_DIV(padding_bot, stride_height);
     clmn_beg = CEIL_DIV(padding_left, stride_width);
-    clmn_end = out_width - CEIL_DIV(padding_right, stride_width);
+    clmn_end = out.width - CEIL_DIV(padding_right, stride_width);
 
     if ((row_end - row_beg > 0) && (clmn_end - clmn_beg > 0)) {
         maxpool_hwc_nopad<io_T>(
-            row_beg, row_end, clmn_beg, clmn_end,
-            stride_width, stride_height, padding_top,
-            padding_bot, padding_left, padding_right,
-            in_ftrs, out_ftrs, channels_num, kernel_height,
-            kernel_width, in_height, in_width, out_width,
-            out_height);
+                row_beg, row_end, clmn_beg, clmn_end,
+                stride_width, stride_height, padding_top,
+                padding_bot, padding_left, padding_right,
+                in, out,
+                kernel_height, kernel_width);
     }
     // Phase 2: Process border part with more complex algorithm
     // (usually significantly smaller part of computations)
@@ -215,29 +207,29 @@ static inline void __attribute__((always_inline)) maxpool_hwc_pad(
             perc_areas[areas_num].row_beg = 0;
             perc_areas[areas_num].row_end = CEIL_DIV(padding_top, stride_height);
             perc_areas[areas_num].clmn_beg = 0;
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num++].clmn_end = out.width;
         }
         if (padding_bot) {
-            perc_areas[areas_num].row_beg = out_height - CEIL_DIV(padding_bot, stride_height);
-            perc_areas[areas_num].row_end = out_height;
+            perc_areas[areas_num].row_beg = out.height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].row_end = out.height;
             perc_areas[areas_num].clmn_beg = 0;
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num++].clmn_end = out.width;
         }
         if (padding_left) {
             perc_areas[areas_num].row_beg = CEIL_DIV(padding_top, stride_height);
-            perc_areas[areas_num].row_end = out_height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].row_end = out.height - CEIL_DIV(padding_bot, stride_height);
             perc_areas[areas_num].clmn_beg = 0;
             perc_areas[areas_num++].clmn_end = CEIL_DIV(padding_left, stride_width);
         }
         if (padding_right) {
             perc_areas[areas_num].row_beg = CEIL_DIV(padding_top, stride_height);
-            perc_areas[areas_num].row_end = out_height - CEIL_DIV(padding_bot, stride_height);
-            perc_areas[areas_num].clmn_beg = out_width - CEIL_DIV(padding_right, stride_width);
-            perc_areas[areas_num++].clmn_end = out_width;
+            perc_areas[areas_num].row_end = out.height - CEIL_DIV(padding_bot, stride_height);
+            perc_areas[areas_num].clmn_beg = out.width - CEIL_DIV(padding_right, stride_width);
+            perc_areas[areas_num++].clmn_end = out.width;
         }
 
         for (int area_idx = 0; area_idx < areas_num; ++area_idx) {
-            for (int ch_idx = 0; ch_idx < channels_num - (channels_num & 1); ch_idx+=2) {
+            for (int ch_idx = 0; ch_idx < in.ch - (in.ch & 1); ch_idx+=2) {
                 for (int H_idx = perc_areas[area_idx].row_beg; H_idx < perc_areas[area_idx].row_end; H_idx++) {
                     for (int W_idx = perc_areas[area_idx].clmn_beg; W_idx < perc_areas[area_idx].clmn_end; W_idx++) {
                         // Define area of input and filter for convolution
@@ -245,29 +237,31 @@ static inline void __attribute__((always_inline)) maxpool_hwc_pad(
                         int top_comp = -MIN((H_idx * stride_height) - padding_top, 0);
                         int left_comp = -MIN((W_idx * stride_width) - padding_left, 0);
 
-                        int right_comp = -MIN(in_width - ((W_idx * stride_width) - padding_left + kernel_width), 0);
-                        int bottom_comp = -MIN(in_height - ((H_idx * stride_height) - padding_top + kernel_height), 0);
+                        int right_comp = -MIN(in.width - ((W_idx * stride_width) - padding_left + kernel_width), 0);
+                        int bottom_comp = -MIN(in.height - ((H_idx * stride_height) - padding_top + kernel_height), 0);
 
                         int rows = kernel_height - top_comp - bottom_comp;
                         int clmns = kernel_width - right_comp - left_comp;
 
-                        const MLI_PTR(io_T) in_ptr =
-                                in_ftrs +  // starting point
-                                channels_num * in_width *
-                                (H_idx * stride_height - padding_top + top_comp) +            // move to row
-                                channels_num * ((W_idx * stride_width) - padding_left + left_comp) +  // move to column
-                                ch_idx;
+                        // Define area of input and filter for convolution
+                        const MLI_PTR(io_T) in_ptr = in.ptr
+                                + in.row_mem_stride * (H_idx * stride_height - padding_top + top_comp)  // move to row
+                                + in.col_mem_stride * (W_idx * stride_width - padding_left + left_comp) // move to column
+                                + ch_idx;                                                               // move to channel
 
                         // Core Max
-                        v2q15_t max_val = reduce_max2D_hwc_v<io_T>(in_ptr, clmns, rows, channels_num, in_width, false);
+                        v2q15_t max_val = reduce_max2D_hwc_v<io_T>(
+                            in_ptr, clmns, rows, in.ch, in.col_mem_stride, in.row_mem_stride, false);
 
                         // Write result
-                        mli_prv_store_2_samples(&out_ftrs[ch_idx + (H_idx * out_width + W_idx) * channels_num], max_val);
+                        mli_prv_store_2_samples(&out.ptr[
+                                out.row_mem_stride * H_idx
+                                + out.col_mem_stride * W_idx
+                                + ch_idx], max_val);
                     }
                 }
             }
-            if (channels_num & 1)
-            {
+            if (in.ch & 1) {
                 for (int H_idx = perc_areas[area_idx].row_beg; H_idx < perc_areas[area_idx].row_end; H_idx++) {
                     for (int W_idx = perc_areas[area_idx].clmn_beg; W_idx < perc_areas[area_idx].clmn_end; W_idx++) {
                         // Define area of input and filter for convolution
@@ -275,24 +269,25 @@ static inline void __attribute__((always_inline)) maxpool_hwc_pad(
                         int top_comp = -MIN((H_idx * stride_height) - padding_top, 0);
                         int left_comp = -MIN((W_idx * stride_width) - padding_left, 0);
 
-                        int right_comp = -MIN(in_width - ((W_idx * stride_width) - padding_left + kernel_width), 0);
-                        int bottom_comp = -MIN(in_height - ((H_idx * stride_height) - padding_top + kernel_height), 0);
+                        int right_comp = -MIN(in.width - ((W_idx * stride_width) - padding_left + kernel_width), 0);
+                        int bottom_comp = -MIN(in.height - ((H_idx * stride_height) - padding_top + kernel_height), 0);
 
                         int rows = kernel_height - top_comp - bottom_comp;
                         int clmns = kernel_width - right_comp - left_comp;
 
-                        const MLI_PTR(io_T) in_ptr =
-                                in_ftrs +  // starting point
-                                channels_num * in_width *
-                                (H_idx * stride_height - padding_top + top_comp) +            // move to row
-                                channels_num * ((W_idx * stride_width) - padding_left + left_comp) +  // move to column
-                                channels_num - 1;
+                        const MLI_PTR(io_T) in_ptr = in.ptr
+                                + in.row_mem_stride * (H_idx * stride_height - padding_top + top_comp)  // move to row
+                                + in.col_mem_stride * (W_idx * stride_width - padding_left + left_comp) // move to column
+                                + in.ch -  1;                                                           // move to channel
 
                         // Core Max
-                        io_T max_val = reduce_max2D_hwc<io_T>(in_ptr, clmns, rows, channels_num, in_width, false);
+                        io_T max_val = reduce_max2D_hwc<io_T>(
+                            in_ptr, clmns, rows, in.col_mem_stride, in.row_mem_stride, false);
 
-                        // Write result
-                        out_ftrs[channels_num - 1 + (H_idx * out_width + W_idx) * channels_num] = max_val;
+                        // Write results
+                        out.ptr[out.row_mem_stride * H_idx
+                                + out.col_mem_stride * W_idx
+                                + out.ch - 1] = max_val;
                     }
                 }
             }

--- a/lib/src/kernels/pooling/mli_krn_maxpool_hwc_fx16.cc
+++ b/lib/src/kernels/pooling/mli_krn_maxpool_hwc_fx16.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_maxpool_hwc_fx16_k2x2_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -63,20 +67,19 @@ mli_status mli_krn_maxpool_hwc_fx16_k2x2_nopad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -89,17 +92,8 @@ mli_status mli_krn_maxpool_hwc_fx16_k2x2_nopad(const mli_tensor * in, const mli_
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -116,9 +110,13 @@ mli_status mli_krn_maxpool_hwc_fx16_k3x3_nopad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -138,20 +136,19 @@ mli_status mli_krn_maxpool_hwc_fx16_k3x3_nopad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -164,17 +161,8 @@ mli_status mli_krn_maxpool_hwc_fx16_k3x3_nopad(const mli_tensor * in, const mli_
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -191,9 +179,13 @@ mli_status mli_krn_maxpool_hwc_fx16_k2x2_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -213,20 +205,19 @@ mli_status mli_krn_maxpool_hwc_fx16_k2x2_krnpad(const mli_tensor * in, const mli
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -239,17 +230,8 @@ mli_status mli_krn_maxpool_hwc_fx16_k2x2_krnpad(const mli_tensor * in, const mli
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -266,9 +248,13 @@ mli_status mli_krn_maxpool_hwc_fx16_k3x3_krnpad(const mli_tensor * in, const mli
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -288,20 +274,19 @@ mli_status mli_krn_maxpool_hwc_fx16_k3x3_krnpad(const mli_tensor * in, const mli
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -314,17 +299,8 @@ mli_status mli_krn_maxpool_hwc_fx16_k3x3_krnpad(const mli_tensor * in, const mli
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -341,9 +317,13 @@ mli_status mli_krn_maxpool_hwc_fx16_generic(const mli_tensor * in, const mli_poo
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int16_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -363,20 +343,19 @@ mli_status mli_krn_maxpool_hwc_fx16_generic(const mli_tensor * in, const mli_poo
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int16_t) in_ftrs = (MLI_PTR(int16_t ))in->data;
-    MLI_OUT_PTR(int16_t) out_ftrs = (MLI_OUT_PTR(int16_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int16_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -389,17 +368,8 @@ mli_status mli_krn_maxpool_hwc_fx16_generic(const mli_tensor * in, const mli_poo
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_maxpool_hwc_fx8.cc
+++ b/lib/src/kernels/pooling/mli_krn_maxpool_hwc_fx8.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_maxpool_hwc_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -63,20 +67,19 @@ mli_status mli_krn_maxpool_hwc_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -89,17 +92,8 @@ mli_status mli_krn_maxpool_hwc_fx8_k2x2_nopad(const mli_tensor * in, const mli_p
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -116,9 +110,13 @@ mli_status mli_krn_maxpool_hwc_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -138,20 +136,19 @@ mli_status mli_krn_maxpool_hwc_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -164,17 +161,8 @@ mli_status mli_krn_maxpool_hwc_fx8_k3x3_nopad(const mli_tensor * in, const mli_p
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -191,9 +179,13 @@ mli_status mli_krn_maxpool_hwc_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -213,20 +205,19 @@ mli_status mli_krn_maxpool_hwc_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -239,17 +230,8 @@ mli_status mli_krn_maxpool_hwc_fx8_k2x2_krnpad(const mli_tensor * in, const mli_
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -266,9 +248,13 @@ mli_status mli_krn_maxpool_hwc_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -288,20 +274,19 @@ mli_status mli_krn_maxpool_hwc_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -314,17 +299,8 @@ mli_status mli_krn_maxpool_hwc_fx8_k3x3_krnpad(const mli_tensor * in, const mli_
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -341,9 +317,13 @@ mli_status mli_krn_maxpool_hwc_fx8_generic(const mli_tensor * in, const mli_pool
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -363,20 +343,19 @@ mli_status mli_krn_maxpool_hwc_fx8_generic(const mli_tensor * in, const mli_pool
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -389,17 +368,8 @@ mli_status mli_krn_maxpool_hwc_fx8_generic(const mli_tensor * in, const mli_pool
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.fx.frac_bits = in->el_params.fx.frac_bits;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_maxpool_hwc_sa8.cc
+++ b/lib/src/kernels/pooling/mli_krn_maxpool_hwc_sa8.cc
@@ -41,9 +41,13 @@ mli_status mli_krn_maxpool_hwc_sa8_k2x2_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -63,20 +67,19 @@ mli_status mli_krn_maxpool_hwc_sa8_k2x2_nopad(const mli_tensor * in, const mli_p
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -89,17 +92,8 @@ mli_status mli_krn_maxpool_hwc_sa8_k2x2_nopad(const mli_tensor * in, const mli_p
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -116,9 +110,13 @@ mli_status mli_krn_maxpool_hwc_sa8_k3x3_nopad(const mli_tensor * in, const mli_p
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -138,20 +136,19 @@ mli_status mli_krn_maxpool_hwc_sa8_k3x3_nopad(const mli_tensor * in, const mli_p
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -164,17 +161,8 @@ mli_status mli_krn_maxpool_hwc_sa8_k3x3_nopad(const mli_tensor * in, const mli_p
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -191,9 +179,13 @@ mli_status mli_krn_maxpool_hwc_sa8_k2x2_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -213,20 +205,19 @@ mli_status mli_krn_maxpool_hwc_sa8_k2x2_krnpad(const mli_tensor * in, const mli_
 #if 2
     MLI_CHECK_AND_FIX(kernel_height, 2);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -239,17 +230,8 @@ mli_status mli_krn_maxpool_hwc_sa8_k2x2_krnpad(const mli_tensor * in, const mli_
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -266,9 +248,13 @@ mli_status mli_krn_maxpool_hwc_sa8_k3x3_krnpad(const mli_tensor * in, const mli_
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -288,20 +274,19 @@ mli_status mli_krn_maxpool_hwc_sa8_k3x3_krnpad(const mli_tensor * in, const mli_
 #if 3
     MLI_CHECK_AND_FIX(kernel_height, 3);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -314,17 +299,8 @@ mli_status mli_krn_maxpool_hwc_sa8_k3x3_krnpad(const mli_tensor * in, const mli_
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }
@@ -341,9 +317,13 @@ mli_status mli_krn_maxpool_hwc_sa8_generic(const mli_tensor * in, const mli_pool
     int32_t padding_bot = cfg->padding_bottom;
     int32_t padding_left = cfg->padding_left;
     int32_t padding_right = cfg->padding_right;
-    int32_t channels_num = in->shape[FMAP_C_DIM_HWC];
     int32_t kernel_height = cfg->kernel_height;
     int32_t kernel_width = cfg->kernel_width;
+
+    // Define Data dimensions
+    auto in_prv = mli_prv_get_tensor_hwc<MLI_PTR(int8_t), MLI_PTR_IS_XY>(in,
+            0); // channels
+
     // assign hard coded values for this variation to some variables
 #if 0
     MLI_CHECK_AND_FIX(stride_width, 0);
@@ -363,20 +343,19 @@ mli_status mli_krn_maxpool_hwc_sa8_generic(const mli_tensor * in, const mli_pool
 #if 0
     MLI_CHECK_AND_FIX(kernel_height, 0);
 #endif
-#if 0
-    MLI_CHECK_AND_FIX(channels_num, 0);
-#endif
-
-    // Data pointers
-    MLI_PTR(int8_t) in_ftrs = (MLI_PTR(int8_t ))in->data;
-    MLI_OUT_PTR(int8_t) out_ftrs = (MLI_OUT_PTR(int8_t ))out->data;
 
     // Define Data dimensions
-    const int32_t in_height = in->shape[FMAP_H_DIM_HWC];
-    const int32_t in_width = in->shape[FMAP_W_DIM_HWC];
+    const int32_t out_width = CEIL_DIV(in_prv.width + padding_left + padding_right - kernel_width + 1, stride_width);
+    const int32_t out_height = CEIL_DIV(in_prv.height + padding_top + padding_bot - kernel_height + 1, stride_height);
 
-    const int32_t out_width = CEIL_DIV(in_width + padding_left + padding_right - kernel_width + 1, stride_width);
-    const int32_t out_height = CEIL_DIV(in_height + padding_top + padding_bot - kernel_height + 1, stride_height);
+    // fill output tensor parameters
+    out->el_type = in->el_type;
+    out->rank = in->rank;
+    out->shape[FMAP_H_DIM_HWC] = out_height;
+    out->shape[FMAP_W_DIM_HWC] = out_width;
+    out->shape[FMAP_C_DIM_HWC] = in_prv.ch;
+    out->el_params.asym = in->el_params.asym;
+    const auto out_prv = mli_prv_get_tensor_hwc<MLI_OUT_PTR(int8_t), MLI_OUT_PTR_IS_XY>(out);
 
     const int32_t row_beg = 0;
     const int32_t row_end = out_height;
@@ -389,17 +368,8 @@ mli_status mli_krn_maxpool_hwc_sa8_generic(const mli_tensor * in, const mli_pool
         row_beg, row_end, clmn_beg, clmn_end,
         stride_width, stride_height, padding_top,
         padding_bot, padding_left, padding_right, 
-        in_ftrs, out_ftrs, channels_num, kernel_height,
-        kernel_width, in_height, in_width, out_width,
-        out_height);
-
-    // fill output tensor parameters
-    out->el_type = in->el_type;
-    out->rank = in->rank;
-    out->shape[FMAP_H_DIM_HWC] = out_height;
-    out->shape[FMAP_W_DIM_HWC] = out_width;
-    out->shape[FMAP_C_DIM_HWC] = channels_num;
-    out->el_params.asym = in->el_params.asym;
+        in_prv, out_prv,
+        kernel_height, kernel_width);
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/kernels/pooling/mli_krn_reduce_sum2d.h
+++ b/lib/src/kernels/pooling/mli_krn_reduce_sum2d.h
@@ -174,21 +174,21 @@ static inline accum40_t reduce_sum2D_hwc(
         MLI_PTR(io_T) __restrict in,
         uint32_t width,
         uint32_t height,
-        uint32_t channels,
-        uint32_t in_row_step,
+        uint32_t col_mem_stride,
+        uint32_t row_mem_stride,
         int16_t mul) {
     accum40_t acc40 = fx_create_a40(0x0, 0x0);
     if (width == 1){
 #pragma clang loop unroll(full)
         for (int row = 0; row < height; row++) {
             acc40 = fx_a40_mac_q15(acc40, *in, mul);
-            in += channels * in_row_step;
+            in += row_mem_stride;
         }
     } else if( height == 1) {
 #pragma clang loop unroll(full)
         for (int clmn = 0; clmn < width; clmn++) {
             acc40 = fx_a40_mac_q15(acc40, *in, mul);
-            in += channels;
+            in += col_mem_stride;
         }
     } else {
 #pragma clang loop unroll(full)
@@ -196,9 +196,9 @@ static inline accum40_t reduce_sum2D_hwc(
 #pragma clang loop unroll(full)
             for (int clmn = 0; clmn < width; clmn++) {
                 acc40 = fx_a40_mac_q15(acc40, *in, mul);
-                in += channels;
+                in += col_mem_stride;
             }
-            in += channels * (in_row_step - width);
+            in += row_mem_stride - col_mem_stride * width;
         }
     }
     return acc40;
@@ -209,8 +209,8 @@ static inline v2accum40_t __attribute__((always_inline)) reduce_sum2D_hwc_v(
         MLI_PTR(io_T) __restrict in,
         uint32_t width,
         uint32_t height,
-        uint32_t channels,
-        uint32_t in_row_step,
+        uint32_t col_mem_stride,
+        uint32_t row_mem_stride,
         int16_t mul) {
 
     v2accum40_t v2acc40 = {0, 0};
@@ -219,13 +219,13 @@ static inline v2accum40_t __attribute__((always_inline)) reduce_sum2D_hwc_v(
 #pragma clang loop unroll(full)
         for (int row = 0; row < height; row++) {
             v2acc40 = fx_v2a40_mac_v2q15(v2acc40, mli_prv_load_2_samples(in), v2mul);
-            in += in_row_step * channels;
+            in += row_mem_stride;
         }
     } else if (height == 1){
 #pragma clang loop unroll(full)
         for (int clmn = 0; clmn < width; clmn++) {
             v2acc40 = fx_v2a40_mac_v2q15(v2acc40, mli_prv_load_2_samples(in), v2mul);
-            in += channels;
+            in += col_mem_stride;
         }
     } else {
 #pragma clang loop unroll(full)
@@ -233,9 +233,9 @@ static inline v2accum40_t __attribute__((always_inline)) reduce_sum2D_hwc_v(
 #pragma clang loop unroll(full)
             for (int clmn = 0; clmn < width; clmn++) {
                 v2acc40 = fx_v2a40_mac_v2q15(v2acc40, mli_prv_load_2_samples(in), v2mul);
-                in += channels;
+                in += col_mem_stride;
             }
-            in += channels * (in_row_step - width);
+            in += row_mem_stride - col_mem_stride * width;
         }
     }
     return v2acc40;

--- a/lib/src/private/mli_private_types.h
+++ b/lib/src/private/mli_private_types.h
@@ -13,12 +13,42 @@
 #include "mli_config.h"
 #include "mli_types.h"
 
+/**
+ * Private tensor struct typically used for pooling/conv2d/depthwise_conv2d
+ * inputs and outputs.
+ */
+template <typename T>
+struct tensor_private_t {
+    T __restrict ptr;
+    int32_t width;
+    int32_t height;
+    int32_t ch;
+    int32_t col_mem_stride;
+    int32_t row_mem_stride;
+    int32_t ch_mem_stride;
+};
+
+/**
+ * Private weights tensor struct typically used for conv2d/depthwise_conv2d.
+ */
+template <typename T>
+struct conv2d_weights_tensor_private_t {
+    T __restrict ptr;
+    int32_t kernel_width;
+    int32_t kernel_height;
+    int32_t in_ch;
+    int32_t out_ch;
+    int32_t col_mem_stride;
+    int32_t row_mem_stride;
+    int32_t in_ch_mem_stride;
+    int32_t out_ch_mem_stride;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct
-{
+typedef struct {
     uint32_t row_beg;
     uint32_t row_end;
     uint32_t clmn_beg;

--- a/lib/src/private/mli_prv_tensor.h
+++ b/lib/src/private/mli_prv_tensor.h
@@ -198,8 +198,10 @@ static inline mli_status __attribute__ ((always_inline)) mli_prv_copy_tensor_for
     if (check != MLI_STATUS_OK)
           return check;
 
-    for (int idx = 0; idx < src->rank; idx++)
+    for (int idx = 0; idx < src->rank; idx++) {
         dst->shape[idx] = src->shape[idx];
+        dst->mem_stride[idx] = src->mem_stride[idx];
+    }
 
     dst->rank = src->rank;
     dst->el_type = src->el_type;

--- a/lib/src/private/mli_prv_tensor.h
+++ b/lib/src/private/mli_prv_tensor.h
@@ -20,13 +20,172 @@
 #include "mli_private_types.h"
 #include <arc/arc_intrinsics.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // with a shift of 31, we cannot represent the value one. So we shift only 30
 // and an extra multiplication of 2 is done when bias is loaded.
 #define MLI_BIAS_MUL_SHIFT 30
+
+// Enable the below define to let the functions in this file
+// assume that the user has set all the mli_tensor_t mem_strides to zero.
+// Using this define can result in slight performance increase.
+//#define MLI_PRV_TENSOR_CALC_MEM_STRIDES
+
+#ifdef MLI_PRV_TENSOR_CALC_MEM_STRIDES
+#define MLI_PRV_TENSOR_CALC_MEM_STRIDES_VAL true
+#else
+#define MLI_PRV_TENSOR_CALC_MEM_STRIDES_VAL false
+#endif
+
+// To prevent a compiler name mangling issue, type_is_xy should be true if and only if T has __xy.
+template <typename T, bool type_is_xy> __attribute__((always_inline))
+static inline tensor_private_t<T> mli_prv_get_tensor_chw (
+        const mli_tensor *in,
+        int fix_ch = 0)
+{
+    int ch     = (int)in->shape[FMAP_C_DIM_CHW];
+    int height = (int)in->shape[FMAP_H_DIM_CHW];
+    int width  = (int)in->shape[FMAP_W_DIM_CHW];
+    int ch_mem_stride  = in->mem_stride[FMAP_C_DIM_CHW];
+    int row_mem_stride = in->mem_stride[FMAP_H_DIM_CHW];
+
+    if (fix_ch != 0) {
+        MLI_ASSERT(ch == fix_ch);
+        ch = fix_ch;
+    }
+
+    if (MLI_PRV_TENSOR_CALC_MEM_STRIDES_VAL || row_mem_stride == 0) {
+        // user does not supply memory strides, hence we calculate them.
+        MLI_ASSERT(ch_mem_stride == 0);
+        MLI_ASSERT(row_mem_stride == 0);
+        MLI_ASSERT(in->mem_stride[FMAP_W_DIM_CHW] == 0);
+
+        row_mem_stride = width;
+        ch_mem_stride = width * height;
+    }
+
+    return tensor_private_t<T> {
+        (T)in->data, width, height, ch, 1, row_mem_stride, ch_mem_stride };
+}
+
+// To prevent a compiler name mangling issue, type_is_xy should be true if and only if T has __xy.
+template <typename T, bool type_is_xy> __attribute__((always_inline))
+static inline tensor_private_t<T> mli_prv_get_tensor_hwc (
+        const mli_tensor *in,
+        int fix_ch = 0)
+{
+    int height = (int)in->shape[FMAP_H_DIM_HWC];
+    int width  = (int)in->shape[FMAP_W_DIM_HWC];
+    int ch     = (int)in->shape[FMAP_C_DIM_HWC];
+    int row_mem_stride = in->mem_stride[FMAP_H_DIM_HWC];
+    int col_mem_stride = in->mem_stride[FMAP_W_DIM_HWC];
+
+    if (fix_ch != 0) {
+        MLI_ASSERT(ch == fix_ch);
+        ch = fix_ch;
+    }
+
+    if (MLI_PRV_TENSOR_CALC_MEM_STRIDES_VAL || col_mem_stride == 0) {
+        // user does not supply memory strides, hence we calculate them.
+        MLI_ASSERT(row_mem_stride == 0);
+        MLI_ASSERT(col_mem_stride == 0);
+        MLI_ASSERT(in->mem_stride[FMAP_C_DIM_HWC] == 0);
+
+        col_mem_stride = ch;
+        row_mem_stride = ch * width;
+    }
+
+    return tensor_private_t<T> {
+        (T)in->data, width, height, ch, col_mem_stride, row_mem_stride, 1 };
+}
+
+// To prevent a compiler name mangling issue, type_is_xy should be true if and only if T has __xy.
+template <typename T, bool type_is_xy> __attribute__((always_inline))
+static inline conv2d_weights_tensor_private_t<T> mli_prv_get_conv2d_weights_tensor_nhwc (
+        const mli_tensor *weights,
+        const int fix_in_ch = 0,
+        const int fix_width = 0,
+        const int fix_height = 0)
+{
+    int out_ch = (int)weights->shape[KRNL_C_DIM_HWC];
+    int height = (int)weights->shape[KRNL_H_DIM_HWC];
+    int width  = (int)weights->shape[KRNL_W_DIM_HWC];
+    int in_ch  = (int)weights->shape[KRNL_D_DIM_HWC];
+    int out_ch_mem_stride = weights->mem_stride[KRNL_C_DIM_HWC];
+    int row_mem_stride    = weights->mem_stride[KRNL_H_DIM_HWC];
+    int col_mem_stride    = weights->mem_stride[KRNL_W_DIM_HWC];
+
+    if (fix_width != 0) {
+        MLI_ASSERT(width == fix_width);
+        width = fix_width;
+    }
+    if (fix_height != 0) {
+        MLI_ASSERT(height == fix_height);
+        height = fix_height;
+    }
+    if (fix_in_ch != 0) {
+        MLI_ASSERT(in_ch == fix_in_ch);
+        in_ch = fix_in_ch;
+    }
+
+    if (MLI_PRV_TENSOR_CALC_MEM_STRIDES_VAL || col_mem_stride == 0) {
+        // user does not supply memory strides, hence we calculate them.
+        MLI_ASSERT(out_ch_mem_stride == 0);
+        MLI_ASSERT(row_mem_stride == 0);
+        MLI_ASSERT(col_mem_stride == 0);
+        MLI_ASSERT(weights->mem_stride[KRNL_D_DIM_HWC] == 0);
+
+        col_mem_stride    = in_ch;
+        row_mem_stride    = in_ch * width;
+        out_ch_mem_stride = in_ch * width * height;
+    }
+
+    return conv2d_weights_tensor_private_t<T> {
+        (T)weights->data, width, height, in_ch, out_ch, col_mem_stride, row_mem_stride, 1, out_ch_mem_stride };
+}
+
+// To prevent a compiler name mangling issue, type_is_xy should be true if and only if T has __xy.
+template <typename T, bool type_is_xy> __attribute__((always_inline))
+static inline conv2d_weights_tensor_private_t<T> mli_prv_get_conv2d_weights_tensor_1hwn (
+        const mli_tensor *weights,
+        const int fix_width = 0,
+        const int fix_height = 0)
+{
+    int in_ch  = 1;
+    int height = (int)weights->shape[KRNL_DW_H_DIM_HWC];
+    int width  = (int)weights->shape[KRNL_DW_W_DIM_HWC];
+    int out_ch = (int)weights->shape[KRNL_DW_C_DIM_HWC];
+    int row_mem_stride    = weights->mem_stride[KRNL_DW_H_DIM_HWC];
+    int col_mem_stride    = weights->mem_stride[KRNL_DW_W_DIM_HWC];
+    int out_ch_mem_stride = weights->mem_stride[KRNL_DW_C_DIM_HWC];
+
+    MLI_ASSERT(weights->shape[0] == 1);
+    if (fix_width != 0) {
+        MLI_ASSERT(width == fix_width);
+        width = fix_width;
+    }
+    if (fix_height != 0) {
+        MLI_ASSERT(height == fix_height);
+        height = fix_height;
+    }
+
+    if (MLI_PRV_TENSOR_CALC_MEM_STRIDES_VAL || col_mem_stride == 0) {
+        // user does not supply memory strides, hence we calculate them.
+        MLI_ASSERT(weights->mem_stride[0] == 0);
+        MLI_ASSERT(row_mem_stride == 0);
+        MLI_ASSERT(col_mem_stride == 0);
+        MLI_ASSERT(out_ch_mem_stride == 0);
+
+        col_mem_stride    = out_ch;
+        row_mem_stride    = out_ch * width;
+        out_ch_mem_stride = out_ch * width * height;
+    }
+
+    return conv2d_weights_tensor_private_t<T> {
+        (T)weights->data, width, height, in_ch, out_ch, col_mem_stride, row_mem_stride, out_ch_mem_stride };
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline uint32_t __attribute__ ((always_inline)) mli_prv_norm(int32_t val) {
     return _norm(val);

--- a/lib/src/private/src/mli_check.cc
+++ b/lib/src/private/src/mli_check.cc
@@ -21,6 +21,10 @@
 
 #pragma Code(".mli_lib")
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /******************************************************
  *  mli_tensor data structure correctness checking
  ******************************************************/
@@ -32,7 +36,7 @@ mli_status mli_chk_tensor (const mli_tensor * in) {
     fail |= MLI_CHECK(mli_hlp_tensor_element_size (in) * mli_prv_count_elem_num (in) <= in->capacity,
                       "Insufficient tensor capacity");
     if (fail) return MLI_STATUS_BAD_TENSOR;
-    
+
     return MLI_STATUS_OK;
 }
 
@@ -1767,3 +1771,7 @@ mli_status mli_chk_create_subtensor(const mli_tensor *in, const mli_sub_tensor_c
 }
 
 #pragma code()
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
[Change]
- add memory stride support to kernels:
  - depthwise_conv2d + conv2d HWC
  - maxpool HWC/CHW
  - avepool HWC/CHW
  - fully_connected
- memory strides can be put to default such that the compiler
  can optimize more due to common subexpression elimination.
  For this turn on MLI_PRV_TENSOR_CALC_MEM_STRIDES in
  mli_prv_tensor.h.

Signed-off-by: R. Hilkens <hilkens@synopsys.com>