### PR TITLE
[vpx_sigm_tanh_ut]:

### DIFF
--- a/lib/src/bricks/mli_prv_lut_decl.h
+++ b/lib/src/bricks/mli_prv_lut_decl.h
@@ -22,10 +22,6 @@ const int kTransfFuncIntBits = 0;
 const int kMaxFracBitsFx16 = (sizeof(int16_t) * 8) - 1;
 const int kMaxFracBitsFx8 = (sizeof(int8_t) * 8) - 1;   //
 
-const int kAsymZeroPointFx16 = -128;
-const int kAsymScaleFx16 = 256;
-const int kAsymScalePowerFx16 = 8;
-const int kAsymScaleFracBits = 16;
 
 namespace mli {
 namespace krn {
@@ -42,13 +38,13 @@ namespace krn {
 namespace ref {
 template <typename io_T, bool convert = false>
 static void activation_lut(
-    const MLI_PTR(io_T) in,
-    MLI_OUT_PTR(io_T) out,
-    const mli_lut *lut,
-    int8_t scale_frac_bits,
-    int length,
-    int scale = 0,
-    int16_t zero_point = 0);
+        const MLI_PTR(io_T) in,
+        MLI_OUT_PTR(io_T) out,
+        const mli_lut *lut,
+        int8_t in_frac_bits,
+        int length,
+        struct s8asym_quant_params *in_params  = nullptr,
+        struct s8asym_quant_params *out_params = nullptr);
 } // namespace ref
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -57,13 +53,13 @@ static void activation_lut(
 namespace dsp {
 template <typename io_T, bool convert = false>
 static void activation_lut(
-    const MLI_PTR(io_T) in,
-    MLI_OUT_PTR(io_T) out,
-    const mli_lut *lut,
-    int8_t scale_frac_bits,
-    int length,
-    int scale = 0,
-    int16_t zero_point = 0);
+        const MLI_PTR(io_T) in,
+        MLI_OUT_PTR(io_T) out,
+        const mli_lut *lut,
+        int8_t in_frac_bits,
+        int length,
+        struct s8asym_quant_params *in_params  = nullptr,
+        struct s8asym_quant_params *out_params = nullptr);
 } // namespace dsp
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -72,13 +68,13 @@ static void activation_lut(
 namespace vdsp {
 template <typename io_T, bool convert = false>
 static void activation_lut(
-    const MLI_PTR(io_T) in,
-    MLI_OUT_PTR(io_T) out,
-    const mli_lut *lut,
-    int8_t scale_frac_bits,
-    int length,
-    int scale = 0,
-    int16_t zero_point = 0);
+        const MLI_PTR(io_T) in,
+        MLI_OUT_PTR(io_T) out,
+        const mli_lut *lut,
+        int8_t in_frac_bits,
+        int length,
+        struct s8asym_quant_params *in_params  = nullptr,
+        struct s8asym_quant_params *out_params = nullptr);
 } // namespace vdsp
 } // namespace krn
 } // namespace mli

--- a/lib/src/kernels/transform/mli_krn_sigm_fx.cc
+++ b/lib/src/kernels/transform/mli_krn_sigm_fx.cc
@@ -17,6 +17,9 @@
 #include "mli_prv_tensor.h"
 #include "mli_types.h"
 
+const int kSigmAsymZeroPoint = -128;
+const int kSigmOutputShift = 8;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -52,18 +55,27 @@ mli_status mli_krn_sigm_fx16(const mli_tensor* in, mli_tensor* out) {
 }
 
 mli_status mli_krn_sigm_sa8(const mli_tensor* in, mli_tensor* out) {
+    struct s8asym_quant_params in_params;
+    struct s8asym_quant_params out_params;
     mli_status ret = MLI_CHECK_STATUS(mli_chk_basic_activation_sa8(in, out), __func__);
     if (ret != MLI_STATUS_OK) return ret;
     mli_prv_fx_init_dsp_ctrl();
 
+    in_params.offset = in->el_params.asym.zero_point.i16;
+    in_params.scale  = in->el_params.asym.scale.i32;
+    in_params.shift = in->el_params.asym.scale_frac_bits;
+    out_params.offset = kSigmAsymZeroPoint;
+    out_params.scale  = 1;
+    out_params.shift = kSigmOutputShift;
+
     mli_prv_activation_lut_sa8(
-            (MLI_PTR(int8_t))in->data, (MLI_OUT_PTR(int8_t))out->data, &sigmoid_lut_fx16, in->el_params.asym.scale.i32, 
-            in->el_params.asym.scale_frac_bits, in->el_params.asym.zero_point.i16, (int)mli_prv_count_elem_num(in));
+            (MLI_PTR(int8_t))in->data, (MLI_OUT_PTR(int8_t))out->data, &sigmoid_lut_fx16, 
+            &in_params, &out_params, (int)mli_prv_count_elem_num(in));
     // Update output shape
     mli_prv_copy_tensor_format(in, out);
-    out->el_params.asym.zero_point.i16 = kAsymZeroPointFx16;
-    out->el_params.asym.scale.i32 = kAsymScaleFx16;
-    out->el_params.asym.scale_frac_bits = kAsymScaleFracBits;
+    out->el_params.asym.zero_point.i16 = out_params.offset;
+    out->el_params.asym.scale.i32 = out_params.scale;
+    out->el_params.asym.scale_frac_bits = out_params.shift;
 
     return MLI_STATUS_OK;
 }

--- a/lib/src/pal/vdsp/arc_vector_ext.h
+++ b/lib/src/pal/vdsp/arc_vector_ext.h
@@ -167,4 +167,42 @@ static MLI_FORCE_INLINE vNx4int_t vvrelu(vNx4int_t a, int16_t min, int16_t max) 
     return r;
 }
 
+//////////////////////////////////////////////////
+// vvadd_sat
+//////////////////////////////////////////////////
+template <typename T>
+T vvadd_sat(T L, T R);
+
+static MLI_FORCE_INLINE vNx4short_t vvadd_sat(vNx4short_t L, vNx4short_t R) {
+    vNx4short_t out;
+    out.lo = vvadd_sat(L.lo, R.lo);
+    out.hi = vvadd_sat(L.hi, R.hi);
+    return out;
+}
+
+//////////////////////////////////////////////////
+// vvadd_sat
+//////////////////////////////////////////////////
+template <typename T>
+T vvsub_sat(T L, T R);
+
+static MLI_FORCE_INLINE vNx4short_t vvsub_sat(vNx4short_t L, vNx4short_t R) {
+    vNx4short_t out;
+    out.lo = vvsub_sat(L.lo, R.lo);
+    out.hi = vvsub_sat(L.hi, R.hi);
+    return out;
+}
+
+//////////////////////////////////////////////////
+// vvslm_sat
+//////////////////////////////////////////////////
+template <typename T>
+T vvslm_sat(T L, int nbits);
+
+static MLI_FORCE_INLINE vNx4short_t vvslm_sat(vNx4short_t L, int nbits) {
+    vNx4short_t out;
+    out.lo = vvslm_sat(L.lo, (vNx2short_t)nbits);
+    out.hi = vvslm_sat(L.hi, (vNx2short_t)nbits);
+    return out;
+}
 #endif /* ARC_VECTOR_EXT_H_ */

--- a/lib/src/pal/vdsp/mli_math.h
+++ b/lib/src/pal/vdsp/mli_math.h
@@ -30,8 +30,7 @@ MLI_FORCE_INLINE T mli_math_limit_fx(T sign) {
 }
 
 template <typename T>
-MLI_FORCE_INLINE T mli_math_asr_fx(T x, int nbits)
-{
+MLI_FORCE_INLINE T mli_math_asr_fx(T x, int nbits) {
     if (nbits > (sizeof(T) * 8 - 1))
         return x < (T)0 ? -1 : 0;
     if (nbits < 0)
@@ -39,9 +38,20 @@ MLI_FORCE_INLINE T mli_math_asr_fx(T x, int nbits)
     return x >> nbits;
 }
 
+template <>
+MLI_FORCE_INLINE vNx4short_t mli_math_asl_fx(vNx4short_t x, int nbits);
+
+template<>
+MLI_FORCE_INLINE vNx4short_t mli_math_asr_fx(vNx4short_t x, int nbits) {
+    if (nbits > (sizeof(short) * 8 - 1))
+        return x < 0 ? (vNx4short_t)-1 : (vNx4short_t)0;
+    if (nbits < 0)
+        return mli_math_asl_fx<vNx4short_t>(x, (-nbits));
+    return x >> nbits;
+}
+
 template <typename T>
-MLI_FORCE_INLINE T mli_math_asl_fx(T x, int nbits)
-{
+MLI_FORCE_INLINE T mli_math_asl_fx(T x, int nbits) {
     int inp_size = sizeof(T) * 8;
     T hi = 0;
 
@@ -58,9 +68,16 @@ MLI_FORCE_INLINE T mli_math_asl_fx(T x, int nbits)
     return mli_math_limit_fx<T>(hi);
 }
 
+template <>
+MLI_FORCE_INLINE vNx4short_t mli_math_asl_fx(vNx4short_t x, int nbits) {
+    if (nbits < 0)
+        return mli_math_asr_fx<vNx4short_t>(x, (-nbits));
+
+    return vvslm_sat(x, nbits);
+}
+
 template <typename T>
-MLI_FORCE_INLINE T mli_math_asr_rnd_fx(T x, int nbits)
-{
+MLI_FORCE_INLINE T mli_math_asr_rnd_fx(T x, int nbits) {
     T r = 0;
     T last_deleted_mask = (T)1 << (nbits-1);
 
@@ -96,8 +113,7 @@ MLI_FORCE_INLINE T mli_math_asr_rnd_fx(T x, int nbits)
 }
 
 template <typename T>
-MLI_FORCE_INLINE T mli_math_asl_rnd_fx(T x, int nbits)
-{
+MLI_FORCE_INLINE T mli_math_asl_rnd_fx(T x, int nbits) {
     return mli_math_asr_rnd_fx<T>(x, -nbits);
 }
 
@@ -107,20 +123,17 @@ MLI_FORCE_INLINE T mli_math_neg_fx(T x) {
 }
 
 template <typename T>
-MLI_FORCE_INLINE T mli_math_sat_fx(T x, unsigned nbits)
-{
+MLI_FORCE_INLINE T mli_math_sat_fx(T x, unsigned nbits) {
     return mli_math_asr_fx<T>(mli_math_asl_fx<T>(x, nbits), nbits);
 }
 
 template <typename T>
-MLI_FORCE_INLINE T mli_math_abs_fx(T x)
-{    
+MLI_FORCE_INLINE T mli_math_abs_fx(T x) {    
     return x >= (T)0 ? x : mli_math_neg_fx(x);
 }
 
 template <typename T>
-MLI_FORCE_INLINE int mli_math_norm_fx(T x)
-{
+MLI_FORCE_INLINE int mli_math_norm_fx(T x) {
     int inp_size = sizeof(T) * 8;
     T hi = x < (T)0 ? (T)-1 : (T)0;
     int r = 0;
@@ -409,6 +422,14 @@ MLI_FORCE_INLINE l_T mli_math_sub(l_T L, r_T R) {
     return L - R;
 }
 
+template <> 
+MLI_FORCE_INLINE vNx4short_t mli_math_add_fx(vNx4short_t L, vNx4short_t R) {
+    return vvadd_sat(L, R);
+}
+template <> 
+MLI_FORCE_INLINE vNx4short_t mli_math_sub_fx(vNx4short_t L, vNx4short_t R) {
+    return vvsub_sat(L, R);
+}
 // Maximum of two fx operands
 //========================================================================
 template <typename io_T>

--- a/lib/src/private/mli_private_types.h
+++ b/lib/src/private/mli_private_types.h
@@ -99,6 +99,12 @@ struct s8asym_quant_specific_params {
     int out_shift;
 };
 
+struct s8asym_quant_params {
+    int16_t offset;
+    int16_t shift;
+    int32_t scale;
+
+};
 /**
  * @brief Quantization specific parameter to perform correct calculations in MLI_FX quantization scheme.
  */

--- a/lib/src/private/mli_prv_activation_lut.h
+++ b/lib/src/private/mli_prv_activation_lut.h
@@ -39,9 +39,8 @@ void mli_prv_activation_lut_sa8(
         const MLI_PTR(int8_t) in,
         MLI_OUT_PTR(int8_t) out,
         const mli_lut *lut,
-        int scale,
-        int8_t scale_frac_bits,
-        int16_t zero_point,
+        struct s8asym_quant_params *in_params,
+        struct s8asym_quant_params *out_params,
         int length);
 #ifdef __cplusplus
 }

--- a/lib/src/private/src/mli_prv_activation_lut.cc
+++ b/lib/src/private/src/mli_prv_activation_lut.cc
@@ -137,11 +137,10 @@ void mli_prv_activation_lut_sa8(
         const MLI_PTR(int8_t) in,
         MLI_OUT_PTR(int8_t) out,
         const mli_lut *lut,
-        int scale,
-        int8_t scale_frac_bits,
-        int16_t zero_point,
+        struct s8asym_quant_params *in_params,
+        struct s8asym_quant_params *out_params,
         int length) {
-    activation_lut<int8_t, true>(in, out, lut, scale_frac_bits, length, scale, zero_point);
+    activation_lut<int8_t, true>(in, out, lut, 0 /*Unused*/, length, in_params, out_params);
 }
 
 #pragma code()


### PR DESCRIPTION
  - Adding Saturation for ADD/SUB/ASR for VDSP.
  - Solve bugs in LUT VDSP when shift_in is less than 0.
  - Reworking Activation Lut Prototype to pass in/out SA8 Parameters.
  - Update (REF/DSP/VDSP) Code with the new interface.