### PR TITLE
[cmake] aligned with current MLI make files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # the LICENSE file in the root directory of this source tree.
 #
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 project(mli)
 

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -21,6 +21,15 @@ target_link_options(hello_world PRIVATE
     ${MLI_PLATFORM_LINK_OPTIONS}
 )
 
+if (ARC)
+target_link_options(hello_world PRIVATE
+    -m
+    -Coutput=./elf_files/hello_world.map
+    -Hheap=1024K
+    -Hstack=8K
+)
+endif()
+
 set_target_properties(hello_world
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "./elf_files$<0:>"

--- a/examples/hello_world/make/Makefile
+++ b/examples/hello_world/make/Makefile
@@ -42,9 +42,11 @@ else
 BUILD_FOLDER=$(BUILD_FOLDER_ARC)
 TOOL_CHAIN_OPTIONS = \
 	-DARC_CFG_TCF_PATH=$(TCF_FILE) \
-	-DBUILDLIB_DIR=$(BUILDLIB_DIR) \
 	-DCMAKE_TOOLCHAIN_FILE=$(subst \,$(PS),$(METAWARE_ROOT))$(PS)arc$(PS)cmake$(PS)arc-mwdt.toolchain.cmake \
 	-G "Unix Makefiles"
+ifdef BUILDLIB_DIR
+TOOL_CHAIN_OPTIONS += -DBUILDLIB_DIR=$(BUILDLIB_DIR)
+endif
 endif
 
 # Targets

--- a/lib/mli_lib.cmake
+++ b/lib/mli_lib.cmake
@@ -6,7 +6,9 @@
 # the LICENSE file in the root directory of this source tree.
 #
 
-if(_MLI_LIB_CMAKE_LOADED)
+# FLAGS here are similar to lib\make\makefile
+
+if (_MLI_LIB_CMAKE_LOADED)
   return()
 endif()
 set(_MLI_LIB_CMAKE_LOADED TRUE)
@@ -16,15 +18,54 @@ function(get_path_to_mli_lib_cmake MLI_LIB_CMAKE_DIR)
 endfunction()
 get_path_to_mli_lib_cmake(MLI_LIB_CMAKE_DIR)
 
-set(MLI_LIB_SOURCE_FILES
-    ${MLI_LIB_CMAKE_DIR}/src/helpers/src/mli_helpers.cc
-    ${MLI_LIB_CMAKE_DIR}/src/kernels/eltwise/mli_krn_eltwise_add_fx.cc
-    ${MLI_LIB_CMAKE_DIR}/src/kernels/eltwise/mli_krn_eltwise_max_fx.cc
-    ${MLI_LIB_CMAKE_DIR}/src/kernels/eltwise/mli_krn_eltwise_min_fx.cc
-    ${MLI_LIB_CMAKE_DIR}/src/kernels/eltwise/mli_krn_eltwise_mul_fx.cc
-    ${MLI_LIB_CMAKE_DIR}/src/kernels/eltwise/mli_krn_eltwise_sub_fx.cc
-    ${MLI_LIB_CMAKE_DIR}/src/private/src/mli_check.cc
-)
+include(../cmake/settings.cmake)
+
+# To keep code similar to our make files, we use file(GLOB...) to add source files, consider to explicitly add them.
+if (ARC AND (${MLI_PLATFORM} STREQUAL VPX))
+    file(GLOB temp
+        "${MLI_LIB_CMAKE_DIR}/src/helpers/src/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/eltwise/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/pooling/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/bricks/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/private/src/*.cc"
+    )
+    set(MLI_LIB_SOURCE_FILES
+        ${temp}
+        ${MLI_LIB_CMAKE_DIR}/src/kernels/transform/mli_krn_sigm_fx.cc
+        ${MLI_LIB_CMAKE_DIR}/src/kernels/transform/mli_krn_tanh_fx.cc
+        ${MLI_LIB_CMAKE_DIR}/src/kernels/convolution/mli_krn_conv2d_hwcn.cc
+    )
+
+elseif (ARC AND (${MLI_PLATFORM} STREQUAL EM_HS))
+    file(GLOB temp
+        "${MLI_LIB_CMAKE_DIR}/src/helpers/src/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/common/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/convolution/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/data_manip/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/eltwise/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/pooling/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/pooling_chw/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/private/src/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/bricks/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/move/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/transform/*.cc"
+    )
+    set(MLI_LIB_SOURCE_FILES
+        ${temp}
+        ${MLI_LIB_CMAKE_DIR}/src/kernels/transform/mli_krn_sigm_fx.cc
+    )
+
+else()
+    file(GLOB temp
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/eltwise/*.cc"
+        "${MLI_LIB_CMAKE_DIR}/src/kernels/pooling/*hwc*.cc"
+    )
+    set(MLI_LIB_SOURCE_FILES
+        ${temp}
+        ${MLI_LIB_CMAKE_DIR}/src/helpers/src/mli_helpers.cc
+        ${MLI_LIB_CMAKE_DIR}/src/private/src/mli_check.cc
+    )
+endif()
 
 set(MLI_LIB_PUBLIC_INCLUDES
     ${MLI_LIB_CMAKE_DIR}/../include
@@ -43,38 +84,72 @@ set(MLI_LIB_PRIVATE_INCLUDES
     ${MLI_LIB_CMAKE_DIR}/src/kernels/transform
     ${MLI_LIB_CMAKE_DIR}/src/move
     ${MLI_LIB_CMAKE_DIR}/src/pal
-    ${MLI_LIB_CMAKE_DIR}/../examples/auxiliary
 )
 
-if(MSVC)
-set(MLI_LIB_PRIVATE_COMPILE_OPTIONS
-    /W3)
+if (ARC)
+    set(MLI_LIB_PRIVATE_COMPILE_OPTIONS
+        -Hnocopyr
+        -Hpurge
+        -Hsdata0
+        -Hdense_prologue
+        -Wall
+        -Wno-nonportable-include-path
+    )
+elseif (MSVC)
+    set(MLI_LIB_PRIVATE_COMPILE_OPTIONS
+        /W3
+    )
 else()
-set(MLI_LIB_PRIVATE_COMPILE_OPTIONS
-    -Werror
-    -Wno-nonportable-include-path
-)
+    set(MLI_LIB_PRIVATE_COMPILE_OPTIONS
+        -Werror
+        -Wno-nonportable-include-path
+    )
 endif()
 
-list(APPEND MLI_LIB_PRIVATE_COMPILE_DEFINITIONS
-    MLI_BUILD_REFERENCE)
-
-if(NOT DEFINED ROUND_MODE)
+# Supported values for rounding mode: UP/CONVERGENT (depends on platform)
+if (NOT DEFINED ROUND_MODE)
     if(${MLI_PLATFORM} STREQUAL VPX)
         set(ROUND_MODE UP)
-    elseif(${MLI_PLATFORM} STREQUAL EM_HS)
-        set(ROUND_MODE CONVERGENT)
     else()
         set(ROUND_MODE CONVERGENT)
     endif()
 endif()
 
-if(ROUND_MODE STREQUAL CONVERGENT)
+if (${MLI_PLATFORM} STREQUAL VPX)
+    list(APPEND MLI_LIB_PRIVATE_COMPILE_OPTIONS
+        "SHELL: -mllvm -slot_swapping=true")
+    if(ROUND_MODE STREQUAL UP)
+        list(APPEND MLI_LIB_PRIVATE_COMPILE_DEFINITIONS
+            ROUND_UP
+        )
+    elseif(ROUND_MODE STREQUAL CONVERGENT)
+        list(APPEND MLI_LIB_PRIVATE_COMPILE_DEFINITIONS
+            ROUND_CONVERGENT
+        )
+    else()
+        message(FATAL_ERROR rounding mode isn't supported)
+    endif()
+endif()
+
+if (${MLI_PLATFORM} STREQUAL EM_HS)
+    if(ROUND_MODE STREQUAL UP)
+        list(APPEND MLI_LIB_PRIVATE_COMPILE_OPTIONS
+            -Xdsp_ctrl=postshift,guard,up
+        )
+    elseif(ROUND_MODE STREQUAL CONVERGENT)
+        list(APPEND MLI_LIB_PRIVATE_COMPILE_OPTIONS
+            -Xdsp_ctrl=postshift,guard,convergent
+        )
+    else()
+        message(FATAL_ERROR rounding mode isn't supported)
+    endif()
+endif()
+
+if (NOT DEFINED MLI_BUILD_REFERENCE)
+    set(MLI_BUILD_REFERENCE OFF)
+endif()
+if (${MLI_BUILD_REFERENCE} STREQUAL ON)
     list(APPEND MLI_LIB_PRIVATE_COMPILE_DEFINITIONS
-        ROUND_CONVERGENT)
-elseif(ROUND_MODE STREQUAL UP)
-    list(APPEND MLI_LIB_PRIVATE_COMPILE_DEFINITIONS
-        ROUND_UP)
-else()
-    message(FATAL_ERROR "Rounding mode isn't supported!")
+        MLI_BUILD_REFERENCE
+    )
 endif()


### PR DESCRIPTION
[Change]
- Compiler flags are set in a similar way as in MLI make files.
- Add pooling to non-MWDT builds.
- Enable EM/HS+VPX compilations for MWDT as in the MLI make files.