### PR TITLE
[CMake] add MLI_DEBUG_MODE property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,12 @@
 # the LICENSE file in the root directory of this source tree.
 #
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.17)
+
+# set global flags for the compiler; only set EXT_CFLAGS
+# if there are no other methods available.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXT_CFLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXT_CFLAGS}")
 
 project(mli)
 

--- a/lib/make/makefile
+++ b/lib/make/makefile
@@ -6,17 +6,18 @@
 # the LICENSE file in the root directory of this source tree.
 #
 
-RECONFIGURE         ?= ON
+RECONFIGURE         ?= OFF
 DEBUG_BUILD         ?= ON
 OPTMODE             ?= speed
 GEN_EXAMPLES        ?= 1
 MLI_BUILD_REFERENCE ?= OFF
 BUILD_SUBDIR        ?=
+EXT_CFLAGS          ?=
 
 include settings.mk
 
 TOOL_CHAIN_OPTIONS =
-ifndef TCF_FILE
+ifeq ($(TCF_FILE),)
 ifeq ($(O_SYS),Windows)
 TOOL_CHAIN_OPTIONS += -AWin32
 endif
@@ -36,6 +37,10 @@ ifdef ROUND_MODE
 TOOL_CHAIN_OPTIONS += -DROUND_MODE=${ROUND_MODE}
 endif
 
+ifdef MLI_DEBUG_MODE
+TOOL_CHAIN_OPTIONS += -DMLI_DEBUG_MODE=${MLI_DEBUG_MODE}
+endif
+
 ifeq ($(RECONFIGURE),ON)
 CONFIG_TARGET=config
 else
@@ -43,7 +48,7 @@ CONFIG_TARGET=$(BUILD_DIR)/cmake_install.cmake
 endif
 
 # $(MAKE) can be called through CMAKE; but to facilitate parallel builds with -j, we call $(MAKE).
-ifndef TCF_FILE
+ifeq ($(TCF_FILE),)
 lib: $(CONFIG_TARGET)
 	cmake --build $(abspath $(BUILD_DIR)$(PS)$(BUILD_SUBDIR)) --verbose --target install
 else
@@ -56,6 +61,7 @@ all: lib
 $(CONFIG_TARGET):
 	cmake \
 		-DDEBUG_BUILD=$(DEBUG_BUILD) \
+		-DEXT_CFLAGS=$(EXT_CFLAGS) \
 		-DOPTMODE=$(OPTMODE) \
 		-DGEN_EXAMPLES=$(GEN_EXAMPLES) \
 		-DMLI_BUILD_REFERENCE=$(MLI_BUILD_REFERENCE) \

--- a/lib/mli_lib.cmake
+++ b/lib/mli_lib.cmake
@@ -98,9 +98,34 @@ else()
     )
 endif()
 
-if ((DEFINED MLI_BUILD_REFERENCE) AND (MLI_BUILD_REFERENCE STREQUAL "ON"))
+if (DEFINED MLI_BUILD_REFERENCE)
+    set(choices
+        ON
+        OFF
+    )
+    if (NOT MLI_BUILD_REFERENCE IN_LIST choices)
+        message(FATAL_ERROR "invalid MLI_BUILD_REFERENCE ${MLI_BUILD_REFERENCE}")
+    endif()
+    if (MLI_BUILD_REFERENCE STREQUAL "ON")
+        list(APPEND MLI_LIB_PRIVATE_COMPILE_DEFINITIONS
+            MLI_BUILD_REFERENCE
+        )
+    endif()
+endif()
+
+if (DEFINED MLI_DEBUG_MODE)
+    set(choices
+        DBG_MODE_RELEASE
+        DBG_MODE_RET_CODES
+        DBG_MODE_ASSERT
+        DBG_MODE_DEBUG
+        DBG_MODE_FULL
+    )
+    if (NOT MLI_DEBUG_MODE IN_LIST choices)
+        message(FATAL_ERROR "invalid MLI_DEBUG_MODE ${MLI_DEBUG_MODE}")
+    endif()
     list(APPEND MLI_LIB_PRIVATE_COMPILE_DEFINITIONS
-        -DMLI_BUILD_REFERENCE
+        MLI_DEBUG_MODE=${MLI_DEBUG_MODE}
     )
 endif()
 
@@ -143,13 +168,4 @@ elseif (${MLI_PLATFORM} STREQUAL EM_HS)
     else()
         message(FATAL_ERROR "rounding mode ${ROUND_MODE} is not supported")
     endif()
-endif()
-
-if (NOT DEFINED MLI_BUILD_REFERENCE)
-    set(MLI_BUILD_REFERENCE OFF)
-endif()
-if (${MLI_BUILD_REFERENCE} STREQUAL ON)
-    list(APPEND MLI_LIB_PRIVATE_COMPILE_DEFINITIONS
-        MLI_BUILD_REFERENCE
-    )
 endif()


### PR DESCRIPTION
[Change]
- add MLI_DEBUG_MODE to CMake
- small fix
- allows TCF_FILE= empty string
- add global EXT_CFLAGS
- set RECONFIGURE=OFF which prevents unneeded rebuilds
  (if you change flags, set it to ON for your build).
- the rebuild issue is toolchain dependent.