### PR TITLE
handle_negative_out_shift

### DIFF
--- a/lib/src/bricks/impl/mli_prv_quant_vdsp.h
+++ b/lib/src/bricks/impl/mli_prv_quant_vdsp.h
@@ -320,7 +320,11 @@ MLI_FORCE_INLINE void result_cast_relu_store_v(
 
     vNx4short_t accu_result = mli_math_acc_cast_fx<vNx4short_t, vNx4accshort_t>(acc, 0);
     vNx4short_t accu_scaled = mli_math_mul_fx_high(accu_result, quant_params->out_mul);
-    accu_scaled = mli_math_asr_rnd_fx(accu_scaled, quant_params->out_shift - preshift);
+    vNx4short_t shift = quant_params->out_shift - preshift;
+    vNx4short_t shift_right = mli_math_max_fx(shift, 0);
+    accu_scaled = mli_math_asr_rnd_fx(accu_scaled, shift_right);
+    vNx4short_t shift_left = mli_math_max_fx(-shift, 0);
+    accu_scaled = mli_math_asl_fx(accu_scaled, shift_left);
 
 #else
     vNx4int_t accu_result = to_vNx4int_t(acc);

--- a/lib/src/pal/vdsp/mli_math.h
+++ b/lib/src/pal/vdsp/mli_math.h
@@ -207,6 +207,20 @@ MLI_FORCE_INLINE vNx4short_t mli_math_asr_fx(vNx4short_t x, int nbits) {
     return r;
 }
 
+
+template <>
+MLI_FORCE_INLINE vNx2short_t mli_math_asl_fx(vNx2short_t x, vNx2short_t nbits) {
+    return x << nbits;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4short_t mli_math_asl_fx(vNx4short_t x, vNx4short_t nbits) {
+    vNx4short_t r;
+    r.lo = mli_math_asl_fx(x.lo, nbits.lo);
+    r.hi = mli_math_asl_fx(x.hi, nbits.hi);
+    return r;
+}
+
 template <>
 MLI_FORCE_INLINE vNx2short_t mli_math_asr_fx(vNx2short_t x, vNx2short_t nbits) {
     return x >> nbits;


### PR DESCRIPTION
This PR handles the negative value for output shift in convolution and fully_connected kernels.