### PR TITLE
mli_mem_checks

### DIFF
--- a/include/mli_config.h
+++ b/include/mli_config.h
@@ -156,6 +156,7 @@
 #define MLI_CCM_ATT 
 #elif (PLATFORM == V2DSP_VECTOR) && !defined(MLI_BUILD_REFERENCE)
 #define MLI_PTR(p) __vccm p *
+#define MLI_PTR_IS_VCCM true
 #define MLI_PTR_IS_XY false
 #define MLI_OUT_PTR(p) __vccm p *
 #define MLI_OUT_PTR_IS_XY false

--- a/include/mli_types.h
+++ b/include/mli_types.h
@@ -47,6 +47,8 @@ typedef enum _mli_status{
 
     MLI_STATUS_RANK_MISMATCH,
     MLI_STATUS_TYPE_MISMATCH,
+    MLI_STATUS_MEM_BANK_MISMATCH,
+    MLI_STATUS_MISALIGNMENT_ERROR,
     /* other return codes*/
 
     MLI_STATUS_LARGE_ENUM = 0x02000000  /**< Utility field. Prevent size optimization of public enums */

--- a/lib/mli_lib.cmake
+++ b/lib/mli_lib.cmake
@@ -89,6 +89,7 @@ if (ARC)
         -Hdense_prologue
         -Wall
         -Wno-nonportable-include-path
+        -tcf_core_config
     )
 elseif (MSVC)
     set(MLI_LIB_PRIVATE_COMPILE_OPTIONS


### PR DESCRIPTION
Adding memory checks to check that tensor's buffers are allocated in the right memory bank and they are correctly aligned according to the platform.