### PR TITLE
Vectorizing eltwise_mul and eltwise_sub for FX16, FX8 and SA8

### DIFF
--- a/lib/src/kernels/eltwise/impl/mli_krn_eltwise_ref.h
+++ b/lib/src/kernels/eltwise/impl/mli_krn_eltwise_ref.h
@@ -180,8 +180,8 @@ static MLI_FORCE_INLINE void eltwise_op_basic(
         shift_back = (func_type == ELTWISE_MUL) ? IN_SCALE_SHIFT + frac_bits_fx16 : IN_SCALE_SHIFT;
 
         int norm = (scale_factor != 0) ? mli_math_norm_fx<int32_t, int>(scale_factor) : 0;
-        scale16 = mli_math_asr_rnd_fx(scale_factor, 16 - norm);
-        shift_back -= (16 - norm);
+        scale16 = mli_math_asr_rnd_fx(scale_factor, MAX((IN_SCALE_SHIFT - norm), 0));
+        shift_back -= MAX((IN_SCALE_SHIFT - norm), 0);
     }
 
     for (int pos0 = 0; pos0 < shape[0]; pos0++) {

--- a/lib/src/kernels/eltwise/impl/mli_krn_eltwise_vdsp.h
+++ b/lib/src/kernels/eltwise/impl/mli_krn_eltwise_vdsp.h
@@ -37,6 +37,7 @@ static MLI_FORCE_INLINE out_T eltwise_perform_operation(
         (op1, op2, in_offset, out_offset, scale_factor, shift, reverse_sub);
 }
 
+#if defined(__Xvec_guard_bit_option) && (__Xvec_guard_bit_option != 0)
 template <>
 MLI_FORCE_INLINE vNx2short_t eltwise_perform_operation<vNx2short_t, vNx2short_t, ELTWISE_ADD, false>(
         const vNx2short_t op1,
@@ -47,11 +48,12 @@ MLI_FORCE_INLINE vNx2short_t eltwise_perform_operation<vNx2short_t, vNx2short_t,
         const int shift,
         bool reverse_sub) {
     vNx2short_t res;
+    int shift_right = MAX(shift, 0);
+    int shift_left = MAX(-shift, 0);
 
-    vNx2accshort_t tmp = vvcadd_init(op1, op2);
-
-    res = mli_math_acc_cast_fx<vNx2short_t, vNx2accshort_t> (tmp, shift);
-
+    vNx2accshort_t tmp = mli_math_init_accu_add<vNx2short_t, vNx2accshort_t>(op1, op2);
+    res = mli_math_acc_cast_fx<vNx2short_t, vNx2accshort_t> (tmp, shift_right);
+    res = mli_math_asl_fx(res, shift_left);
     return res;
 }
 
@@ -65,13 +67,72 @@ MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, EL
         const int shift,
         bool reverse_sub) {
     vNx4char_t res;
+    int shift_right = MAX(shift, 0);
+    int shift_left = MAX(-shift, 0);
 
-    vNx4accchar_t tmp = vvcadd_init(op1, op2);
-
-    res = mli_math_acc_cast_fx<vNx4char_t, vNx4accchar_t> (tmp, shift);
-
+    vNx4accchar_t tmp = mli_math_init_accu_add<vNx4char_t, vNx4accchar_t>(op1, op2);
+    res = mli_math_acc_cast_fx<vNx4char_t, vNx4accchar_t> (tmp, shift_right);
+    res = mli_math_asl_fx(res, shift_left);
     return res;
 }
+
+#else
+template <>
+MLI_FORCE_INLINE vNx2short_t eltwise_perform_operation<vNx2short_t, vNx2short_t, ELTWISE_ADD, false>(
+        const vNx2short_t op1,
+        const vNx2short_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx2short_t res;
+    int shift_right = MAX(shift, 0);
+    int shift_left = MAX(-shift, 0);
+    int preshift = (shift_right > 0)? 1: 0;
+
+    res = mli_math_add_fx((op1 >> preshift), (op2 >> preshift));
+    /* Compensate preshift bit loss. */
+    if (shift_right == 1) {
+        /* rounding up */
+        res += ((op1 | op2) & preshift);
+    } else {
+        res += ((op1 & op2) & preshift);
+    }
+
+    res = mli_math_asr_rnd_fx(res, shift_right - preshift);
+    res = mli_math_asl_fx(res, shift_left);
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_ADD, false>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res;
+    int shift_right = MAX(shift, 0);
+    int shift_left = MAX(-shift, 0);
+    int preshift = (shift_right > 0)? 1: 0;
+
+    res = mli_math_add_fx((op1 >> preshift), (op2 >> preshift));
+    /* Compensate preshift bit loss. */
+    if (shift_right == 1) {
+        /* rounding app */
+        res += ((op1 | op2) & preshift);
+    } else {
+        res += ((op1 & op2) & preshift);
+    }
+
+    res = mli_math_asr_rnd_fx(res, shift_right - preshift);
+    res = mli_math_asl_fx(res, shift_left);
+    return res;
+}
+#endif
 
 template <>
 MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_ADD, true>(
@@ -86,9 +147,9 @@ MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, EL
 
     /* initialize the accumulator with the input offsets, the output offset, and the rounding value.*/
     int32_t acc_init = -2 * in_offset * scale_factor;
-    acc_init += out_offset << shift;
+    acc_init += (out_offset << shift);
 #ifdef ROUND_UP
-    acc_init += ((shift > 0) ? (1 << (shift-1)) : 0); /* rounding half up */
+    acc_init += ((1 << shift) >> 1); /* rounding half up */
 #else
     #error Rounding mode not supported
 #endif
@@ -96,10 +157,322 @@ MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, EL
     vNx4accint_t acc = mli_math_init_accu<int32_t, vNx4accint_t>(acc_init);
     acc = mli_math_mac_fx(acc, to_vNx4short_t(op1), scale_factor);
     acc = mli_math_mac_fx(acc, to_vNx4short_t(op2), scale_factor);
-
     /* rounding value is already added as part of the acc_init. therefore it shouldn't
        be added again inside the cast functin.*/
     res = mli_math_acc_cast_fx<vNx4char_t, vNx4accint_t, /*round = */false> (acc, shift);
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx2short_t eltwise_perform_operation<vNx2short_t, vNx2short_t, ELTWISE_MUL, false>(
+        const vNx2short_t op1,
+        const vNx2short_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx2short_t res;
+    int shift_left = MAX(-shift, 0);
+    int shift_right = MAX(shift, 0);
+
+    vNx2accint_t tmp = mli_math_mul_fx<vNx2short_t, vNx2accint_t>(op1, op2);
+    vNx2int_t res_32 = mli_math_acc_cast_fx<vNx2int_t, vNx2accint_t>(tmp);
+    res_32 = mli_math_asl_fx(res_32, shift_left);
+    res = mli_math_cast_fx<vNx2int_t, vNx2short_t>(res_32, shift_right);
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_MUL, false>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res;
+    int shift_left = MAX(-shift, 0);
+    int shift_right = MAX(shift, 0);
+
+    vNx4accshort_t tmp = mli_math_mul_fx<vNx4char_t, vNx4accshort_t>(op1, op2);
+    vNx4short_t res_32 = mli_math_acc_cast_fx<vNx4short_t, vNx4accshort_t> (tmp);
+    res_32 = mli_math_asl_fx(res_32, shift_left);
+    res = mli_math_cast_fx<vNx4short_t, vNx4char_t>(res_32, shift_right);
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_MUL, true>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+
+    MLI_ASSERT(shift > 3);
+    int preshift = 3;
+    int preshift_mask = ((1 << preshift) - 1);
+
+    vNx4char_t res;
+    vNx4short_t op1_offset = to_vNx4short_t(op1) - in_offset;
+    vNx4short_t op2_offset = to_vNx4short_t(op2) - in_offset;
+    vNx4accint_t acc = mli_math_mul_fx<vNx4short_t, vNx4accint_t>(op1_offset, op2_offset);
+    vNx4int_t temp = mli_math_acc_cast_fx<vNx4int_t, vNx4accint_t>(acc);
+
+    /*
+     * Each operand is 9 bit. The multiplier needs 18 bit. After scaling, 34 bits are needed.
+     * By preshifting the multiplier output by 3 bits (2 bits to fit in 16 bits and 1 bit for
+     * preshift compensation). We can continue the computation in 16 bits.
+     *
+     * Note: Minimum shift value is 15
+     */
+    vNx4short_t temp_16 = to_vNx4short_t(temp >> preshift);
+    acc = mli_math_mul_fx<vNx4short_t, vNx4accint_t>(temp_16, scale_factor);
+    vNx4int_t comp = (((temp & preshift_mask) * scale_factor) >> preshift);
+    acc = mli_math_add(acc, comp);
+    vNx4short_t res16 = mli_math_acc_cast_fx<vNx4short_t, vNx4accint_t>(acc, shift - preshift);
+    res16 = mli_math_add_fx(res16, vNx4short_t(out_offset));
+    res = mli_math_cast_fx<vNx4short_t, vNx4char_t>(res16);
+
+    return res;
+}
+
+
+#if defined(__Xvec_guard_bit_option) && __Xvec_guard_bit_option != 0
+
+template <>
+MLI_FORCE_INLINE vNx2short_t eltwise_perform_operation<vNx2short_t, vNx2short_t, ELTWISE_SUB, false>(
+        const vNx2short_t op1,
+        const vNx2short_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx2short_t res;
+    vNx2short_t sub1 = reverse_sub? op2 : op1;
+    vNx2short_t sub2 = reverse_sub? op1 : op2;
+    int shift_left = MAX(-shift, 0);
+    int shift_right = MAX(shift, 0);
+
+    vNx2accshort_t acc = mli_math_init_accu_sub<vNx2short_t, vNx2accshort_t>(sub1, sub2);
+    res = mli_math_acc_cast_fx<vNx2short_t, vNx2accshort_t> (acc, shift_right);
+    res = mli_math_asl_fx(res, shift_left);
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_SUB, false>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res;
+    vNx4char_t sub1 = reverse_sub? op2 : op1;
+    vNx4char_t sub2 = reverse_sub? op1 : op2;
+    int shift_left = MAX(-shift, 0);
+    int shift_right = MAX(shift, 0);
+
+    vNx4accchar_t acc = mli_math_init_accu_sub<vNx4char_t, vNx4accchar_t>(sub1, sub2);
+    res = mli_math_acc_cast_fx<vNx4char_t, vNx4accchar_t> (acc, shift_right);
+    res = mli_math_asl_fx(res, shift_left);
+
+    return res;
+}
+
+#else
+
+template <>
+MLI_FORCE_INLINE vNx2short_t eltwise_perform_operation<vNx2short_t, vNx2short_t, ELTWISE_SUB, false>(
+        const vNx2short_t op1,
+        const vNx2short_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx2short_t res;
+    vNx2short_t sub1 = reverse_sub? op2 : op1;
+    vNx2short_t sub2 = reverse_sub? op1 : op2;
+    int shift_left = MAX(-shift, 0);
+    int shift_right = MAX(shift, 0);
+    int preshift = (shift_right > 0)? 1: 0;
+
+    res = mli_math_sub_fx((sub1 >> preshift), (sub2 >> preshift));
+    /* Compensate preshift bit loss. */
+    if (shift_right == 1) {
+        /* rounding up */
+        res += (sub1 & ~sub2 & preshift);
+    } else {
+        res -= (~sub1 & sub2 & preshift);
+    }
+
+    res = mli_math_asr_rnd_fx(res, shift_right - preshift);
+    res = mli_math_asl_fx(res, shift_left);
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_SUB, false>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res;
+    vNx4char_t sub1 = reverse_sub? op2 : op1;
+    vNx4char_t sub2 = reverse_sub? op1 : op2;
+    int shift_left = MAX(-shift, 0);
+    int shift_right = MAX(shift, 0);
+    int preshift = (shift_right > 0)? 1: 0;
+
+    res = mli_math_sub_fx((sub1 >> preshift), (sub2 >> preshift));
+    /* Compensate preshift bit loss. */
+    if (shift_right == 1) {
+        /* rounding up */
+        res += (sub1 & ~sub2 & preshift);
+    } else {
+        res -= (~sub1 & sub2 & preshift);
+    }
+
+    res = mli_math_asr_rnd_fx(res, shift_right - preshift);
+    res = mli_math_asl_fx(res, shift_left);
+
+    return res;
+}
+
+#endif
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_SUB, true>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res;
+    vNx4char_t sub1 = reverse_sub? op2 : op1;
+    vNx4char_t sub2 = reverse_sub? op1 : op2;
+
+    /* initialize the accumulator with the output offset, and the rounding value.*/
+    int32_t acc_init = (out_offset << shift);
+#ifdef ROUND_UP
+    acc_init += ((1 << shift) >> 1); /* rounding half up */
+#else
+    #error Rounding mode not supported
+#endif
+    vNx4accint_t acc = mli_math_init_accu<int32_t, vNx4accint_t>(acc_init);
+    vNx4short_t sub_result = mli_math_sub_fx(to_vNx4short_t(sub1), to_vNx4short_t(sub2));
+    acc = mli_math_mac_fx(acc, sub_result, scale_factor);
+    /* rounding value is already added as part of the acc_init. therefore it shouldn't
+       be added again inside the cast functin.*/
+    res = mli_math_acc_cast_fx<vNx4char_t, vNx4accint_t, /*round = */false> (acc, shift);
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx2short_t eltwise_perform_operation<vNx2short_t, vNx2short_t, ELTWISE_MAX, false>(
+        const vNx2short_t op1,
+        const vNx2short_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx2short_t res = {0};
+
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_MAX, false>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res = {0};
+
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_MAX, true>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res = {0};
+
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx2short_t eltwise_perform_operation<vNx2short_t, vNx2short_t, ELTWISE_MIN, false>(
+        const vNx2short_t op1,
+        const vNx2short_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx2short_t res = {0};
+
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_MIN, false>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res = {0};
+
+
+    return res;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4char_t eltwise_perform_operation<vNx4char_t, vNx4char_t, ELTWISE_MIN, true>(
+        const vNx4char_t op1,
+        const vNx4char_t op2,
+        const int16_t in_offset,
+        const int16_t out_offset,
+        const int16_t scale_factor,
+        const int shift,
+        bool reverse_sub) {
+    vNx4char_t res = {0};
+
+
     return res;
 }
 
@@ -119,8 +492,7 @@ MLI_FORCE_INLINE void eltwise_innerloop(
         const int shift,
         const bool reverse_sub) {
     /* for now only eltwise_add is vectorized. when all functions are vectorized this bool can be removed. */
-    bool vectorized = (func_type == ELTWISE_ADD);
-
+    bool vectorized = (func_type == ELTWISE_ADD || func_type == ELTWISE_MUL || func_type == ELTWISE_SUB);
     /* Dummy Load to get num_lanes, remaining part */
     auto input = mli_prv_load_1vec(op1_ptr);
     int num_lanes = vectorized ? get_number_lanes(input) : 1;
@@ -131,19 +503,20 @@ MLI_FORCE_INLINE void eltwise_innerloop(
             auto val1 = mli_prv_load_1vec(op1_ptr + idx1);
             auto val2 = mli_prv_load_1vec(op2_ptr + idx2);
             val2 = (scalar_op) ? op2_ptr[0] : val2;
-            auto res = mli::krn::eltwise_perform_operation<decltype(val1), decltype(val1), ELTWISE_ADD, convert>(
-                    val1, val2, in_offset, out_offset, scale, shift, reverse_sub);
+            auto res = mli::krn::eltwise_perform_operation<decltype(val1), decltype(val1), func_type, convert>(
+                                                           val1, val2, in_offset, out_offset, scale, shift, reverse_sub);
             mli_prv_store_n_samples(&out_ptr[idx_out], res, remaining_part);
             idx1 += remaining_part;
             idx2 += remaining_part;
             idx_out += remaining_part;
         }
+
         for (int pos = remaining_part; pos < count; pos+=num_lanes) {
             auto val1 = mli_prv_load_1vec(op1_ptr + idx1);
             auto val2 = mli_prv_load_1vec(op2_ptr + idx2);
             /* op1_ptr is always vector, op2_ptr can be scalar or vector. */
             val2 = (scalar_op) ? op2_ptr[0] : val2;
-            auto res = mli::krn::eltwise_perform_operation<decltype(val1), decltype(val1), ELTWISE_ADD, convert>(
+            auto res = mli::krn::eltwise_perform_operation<decltype(val1), decltype(val1), func_type, convert>(
                     val1, val2, in_offset, out_offset, scale, shift, reverse_sub);
             mli_prv_store_n_samples(&out_ptr[idx_out], res);
             idx1 += num_lanes;

--- a/lib/src/pal/vdsp/arc_vector_ext.h
+++ b/lib/src/pal/vdsp/arc_vector_ext.h
@@ -155,8 +155,22 @@ static MLI_FORCE_INLINE vNx4short_t vvadd_sat(vNx4short_t L, vNx4short_t R) {
     return out;
 }
 
+static MLI_FORCE_INLINE vNx2int_t vvadd_sat(vNx2int_t L, vNx2int_t R) {
+    vNx2int_t out;
+    out.lo = vvadd_sat(L.lo, R.lo);
+    out.hi = vvadd_sat(L.hi, R.hi);
+    return out;
+}
+
+static MLI_FORCE_INLINE vNx4int_t vvadd_sat(vNx4int_t L, vNx4int_t R) {
+    vNx4int_t out;
+    out.lo = vvadd_sat(L.lo, R.lo);
+    out.hi = vvadd_sat(L.hi, R.hi);
+    return out;
+}
+
 //////////////////////////////////////////////////
-// vvadd_sat
+// vvsub_sat
 //////////////////////////////////////////////////
 template <typename T>
 T vvsub_sat(T L, T R);
@@ -180,6 +194,21 @@ static MLI_FORCE_INLINE vNx4short_t vvslm_sat(vNx4short_t L, int nbits) {
     out.hi = vvslm_sat(L.hi, (vNx2short_t)nbits);
     return out;
 }
+
+static MLI_FORCE_INLINE vNx2int_t vvslm_sat(vNx2int_t L, int nbits) {
+    vNx2int_t out;
+    out.lo = vvslm_sat(L.lo, (vNint_t)nbits);
+    out.hi = vvslm_sat(L.hi, (vNint_t)nbits);
+    return out;
+}
+
+static MLI_FORCE_INLINE vNx4int_t vvslm_sat(vNx4int_t L, int nbits) {
+    vNx4int_t out;
+    out.lo = vvslm_sat(L.lo, nbits);
+    out.hi = vvslm_sat(L.hi, nbits);
+    return out;
+}
+
 
 //////////////////////////////////////////////////
 // MAX

--- a/lib/src/pal/vdsp/mli_math.h
+++ b/lib/src/pal/vdsp/mli_math.h
@@ -103,9 +103,31 @@ MLI_FORCE_INLINE l_T mli_math_sub(l_T L, r_T R) {
 }
 
 template <> 
+MLI_FORCE_INLINE vNx4char_t mli_math_add_fx(vNx4char_t L, vNx4char_t R) {
+    return vvadd_sat(L, R);
+}
+
+template <>
+MLI_FORCE_INLINE vNx2short_t mli_math_add_fx(vNx2short_t L, vNx2short_t R) {
+    return vvadd_sat(L, R);
+}
+
+
+template <>
 MLI_FORCE_INLINE vNx4short_t mli_math_add_fx(vNx4short_t L, vNx4short_t R) {
     return vvadd_sat(L, R);
 }
+
+template <>
+MLI_FORCE_INLINE vNx2int_t mli_math_add_fx(vNx2int_t L, vNx2int_t R) {
+    return vvadd_sat(L, R);
+}
+
+template <>
+MLI_FORCE_INLINE vNx4int_t mli_math_add_fx(vNx4int_t L, vNx4int_t R) {
+    return vvadd_sat(L, R);
+}
+
 template <> 
 MLI_FORCE_INLINE vNx4short_t mli_math_sub_fx(vNx4short_t L, vNx4short_t R) {
     return vvsub_sat(L, R);
@@ -200,9 +222,10 @@ MLI_FORCE_INLINE io_T mli_math_bound_range_fx(io_T in, lr_T L, lr_T R) {
     return out;
 }
 
-
 template <>
-MLI_FORCE_INLINE vNx4short_t mli_math_asl_fx(vNx4short_t x, int nbits);
+MLI_FORCE_INLINE vNx4char_t mli_math_asr_fx(vNx4char_t x, int nbits) {
+    return x >> nbits;
+}
 
 template <>
 MLI_FORCE_INLINE vNx2short_t mli_math_asr_fx(vNx2short_t x, int nbits) {
@@ -214,20 +237,6 @@ MLI_FORCE_INLINE vNx4short_t mli_math_asr_fx(vNx4short_t x, int nbits) {
     vNx4short_t r;
     r.lo = mli_math_asr_fx(x.lo, nbits);
     r.hi = mli_math_asr_fx(x.hi, nbits);
-    return r;
-}
-
-
-template <>
-MLI_FORCE_INLINE vNx2short_t mli_math_asl_fx(vNx2short_t x, vNx2short_t nbits) {
-    return x << nbits;
-}
-
-template <>
-MLI_FORCE_INLINE vNx4short_t mli_math_asl_fx(vNx4short_t x, vNx4short_t nbits) {
-    vNx4short_t r;
-    r.lo = mli_math_asl_fx(x.lo, nbits.lo);
-    r.hi = mli_math_asl_fx(x.hi, nbits.hi);
     return r;
 }
 
@@ -285,6 +294,16 @@ MLI_FORCE_INLINE vNx4int_t mli_math_asr_fx(vNx4int_t x, vNx4int_t nbits) {
 }
 
 template <>
+MLI_FORCE_INLINE vNx4accchar_t mli_math_asr_fx(vNx4accchar_t x, int nbits) {
+    return vvcasrm(x, nbits);
+}
+
+template <>
+MLI_FORCE_INLINE vNx4accchar_t mli_math_asr_fx(vNx4accchar_t x, vNx4char_t nbits) {
+    return vvcasrm(x, nbits);
+}
+
+template <>
 MLI_FORCE_INLINE vNx4accshort_t mli_math_asr_fx(vNx4accshort_t x, vNx4short_t nbits) {
     return __vacc_concat(vvcasrm(__vacc_lo(x), nbits.lo), vvcasrm(__vacc_hi(x), nbits.hi));
 }
@@ -335,12 +354,62 @@ MLI_FORCE_INLINE T mli_math_asl_fx(T x, shift_T nbits) {
 }
 
 template <>
+MLI_FORCE_INLINE vNx4char_t mli_math_asl_fx(vNx4char_t x, int nbits) {
+    return vvslm_sat(x, (vNx4char_t) nbits);
+}
+
+MLI_FORCE_INLINE vNx2short_t mli_math_asl_fx(vNx2short_t x, int nbits) {
+    return vvslm_sat(x, (vNx2short_t)nbits);
+}
+
+template <>
 MLI_FORCE_INLINE vNx4short_t mli_math_asl_fx(vNx4short_t x, int nbits) {
     if (nbits < 0)
         return mli_math_asr_fx<vNx4short_t>(x, (-nbits));
 
     return vvslm_sat(x, nbits);
 }
+
+template <>
+MLI_FORCE_INLINE vNx4int_t mli_math_asl_fx(vNx4int_t x, int nbits) {
+    return vvslm_sat(x, nbits);
+}
+
+template <>
+MLI_FORCE_INLINE vNx2int_t mli_math_asl_fx(vNx2int_t x, int nbits) {
+    return vvslm_sat(x, nbits);
+}
+
+template <>
+MLI_FORCE_INLINE vNx2short_t mli_math_asl_fx(vNx2short_t x, vNx2short_t nbits) {
+    return vvslm_sat(x, nbits);
+}
+
+template <>
+MLI_FORCE_INLINE vNx4short_t mli_math_asl_fx(vNx4short_t x, vNx4short_t nbits) {
+    vNx4short_t r;
+    r.lo = mli_math_asl_fx(x.lo, nbits.lo);
+    r.hi = mli_math_asl_fx(x.hi, nbits.hi);
+    return r;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4accchar_t mli_math_asl_fx(vNx4accchar_t x, int nbits) {
+    vNx4char_t nbits_v = nbits;
+    return vvcslm(x, nbits_v);
+}
+
+template <>
+MLI_FORCE_INLINE vNx4accchar_t mli_math_asl_fx(vNx4accchar_t x, vNx4char_t nbits) {
+    return vvcslm(x, nbits);
+}
+
+template <>
+MLI_FORCE_INLINE vNx2accshort_t mli_math_asl_fx(vNx2accshort_t x, int nbits) {
+    vNx2short_t nbits_v = nbits;
+    return vvcslm(x, nbits_v);
+}
+
 
 template <>
 MLI_FORCE_INLINE vNx4accshort_t mli_math_asl_fx(vNx4accshort_t x, vNx4short_t nbits) {
@@ -381,7 +450,7 @@ MLI_FORCE_INLINE vNx4accint_t mli_math_asl_fx(vNx4accint_t x, int nbits) {
 template <typename T, typename shift_T>
 MLI_FORCE_INLINE T mli_math_asr_rnd_fx(T x, shift_T nbits) {
     T r = 0;
-    T last_deleted_mask = (T)1 << (nbits-1);
+
 
     if (nbits < 0)
         return mli_math_asl_fx<T, shift_T>(x, (-nbits));
@@ -391,12 +460,13 @@ MLI_FORCE_INLINE T mli_math_asr_rnd_fx(T x, shift_T nbits) {
     if (nbits > (sizeof(T) * 8 - 1))
         return 0;
 
-    r = mli_math_asr_fx<T>(x, nbits);
+
     // Rounding up:
     // if the most significant deleted bit is 1, add 1 to the remaining bits.
 #ifdef ROUND_UP
-        if ((last_deleted_mask & x) != (T)0)
-            return mli_math_add_fx<T>(r, 1);
+        T round = (T)((1 << nbits) >> 1);
+        r = mli_math_add_fx<T>(x, round);
+        r = mli_math_asr_fx<T>(r, nbits);
 #endif
 
 
@@ -405,6 +475,8 @@ MLI_FORCE_INLINE T mli_math_asr_rnd_fx(T x, shift_T nbits) {
     // either the least significant of the remaining bits
     // or at least one other deleted bit is 1, add 1 to the remaining bits.
 #ifdef ROUND_CONVERGENT
+    r = mli_math_asr_fx<T>(x, nbits);
+    T last_deleted_mask = (T)((1 << nbits) >> 1);
     if (((x & last_deleted_mask) != (T)0) && 
             (((r & (T)1) != (T)0) ||  ((x & (last_deleted_mask-(T)1))!= (T)0))) {
         return mli_math_add_fx<T>(r, 1);
@@ -466,11 +538,47 @@ MLI_FORCE_INLINE vNx4accint_t mli_math_asr_rnd_fx(vNx4accint_t x, vNx4int_t nbit
 }
 
 template <>
+MLI_FORCE_INLINE vNx4char_t mli_math_asr_rnd_fx(vNx4char_t x, int nbits) {
+    vNx4char_t r;
+
+#ifdef ROUND_UP
+    vNx4char_t round = ((1 << nbits) >> 1);
+    r = mli_math_add_fx(x, round);
+    r = mli_math_asr_fx(r, nbits);
+#endif
+#ifdef ROUND_CONVERGENT
+#error "Convergent rounding not supported"
+#endif
+
+     return r;
+ }
+
+template <>
+MLI_FORCE_INLINE vNx2short_t mli_math_asr_rnd_fx(vNx2short_t x, int nbits) {
+    if (nbits < 0) {
+        return mli_math_asl_fx(x, (-nbits));
+    }
+
+    vNx2short_t r;
+
+#ifdef ROUND_UP
+    vNx2short_t round = ((1 << nbits) >> 1);
+    r = mli_math_add_fx(x, round);
+    r = mli_math_asr_fx(r, nbits);
+ #endif
+ #ifdef ROUND_CONVERGENT
+ #error "Convergent rounding not supported"
+ #endif
+
+     return r;
+ }
+
+template <>
 MLI_FORCE_INLINE vNx4short_t mli_math_asr_rnd_fx(vNx4short_t x, vNx4short_t nbits) {
     vNx4short_t r;
 #ifdef ROUND_UP
     // shift twice to prevent negative shift if nbits = 0
-    r = x + (vNx4short_t)((1 << nbits) >> 1);
+    r = mli_math_add_fx(x, (vNx4short_t)((1 << nbits) >> 1));
 #endif
 #ifdef ROUND_CONVERGENT
 #error "Convergent rounding not supported"
@@ -481,11 +589,45 @@ MLI_FORCE_INLINE vNx4short_t mli_math_asr_rnd_fx(vNx4short_t x, vNx4short_t nbit
 }
 
 template <>
+MLI_FORCE_INLINE vNx4short_t mli_math_asr_rnd_fx(vNx4short_t x, int nbits) {
+    if (nbits < 0) {
+        return mli_math_asl_fx(x, (-nbits));
+    }
+
+    vNx4short_t r;
+
+#ifdef ROUND_UP
+    // shift twice to prevent negative shift if nbits = 0
+    r = mli_math_add_fx(x, (vNx4short_t) ((1 << nbits) >> 1));
+#endif
+#ifdef ROUND_CONVERGENT
+#error "Convergent rounding not supported"
+#endif
+
+    r = mli_math_asr_fx(r, nbits);
+    return r;
+}
+
+template <>
+MLI_FORCE_INLINE vNx4int_t mli_math_asr_rnd_fx(vNx4int_t x, int nbits) {
+    vNx4int_t r;
+
+#ifdef ROUND_UP
+    r = mli_math_add_fx(x, (vNx4int_t) ((1 << nbits) >> 1));
+#endif
+#ifdef ROUND_CONVERGENT
+#error "Convergent rounding not supported"
+#endif
+    r = mli_math_asr_fx(r, nbits);
+    return r;
+}
+
+template <>
 MLI_FORCE_INLINE vNx4int_t mli_math_asr_rnd_fx(vNx4int_t x, vNx4int_t nbits) {
     vNx4int_t r;
 #ifdef ROUND_UP
     // shift twice to prevent negative shift if nbits = 0
-    r = x + (vNx4int_t)((1 << nbits) >> 1);
+    r = mli_math_add_fx(x, (vNx4int_t)((1 << nbits) >> 1));
 #endif
 #ifdef ROUND_CONVERGENT
 #error "Convergent rounding not supported"
@@ -500,7 +642,7 @@ MLI_FORCE_INLINE vNx2int_t mli_math_asr_rnd_fx(vNx2int_t x, int nbits) {
     vNx2int_t r;
 #ifdef ROUND_UP
     // shift twice to prevent negative shift if nbits = 0
-    r = x + (vNx2int_t)((1 << nbits) >> 1);
+    r = mli_math_add_fx(x, (vNx2int_t)((1 << nbits) >> 1));
 #endif
 #ifdef ROUND_CONVERGENT
 #error "Convergent rounding not supported"
@@ -766,18 +908,42 @@ MLI_FORCE_INLINE vNx4int_t mli_math_cast_fx(vNx4short_t in_val) {
 }
 
 template <>
+MLI_FORCE_INLINE vNx4char_t mli_math_cast_fx(vNx4short_t in_val) {
+    in_val = mli_math_bound_range_fx(in_val, INT8_MIN, INT8_MAX);
+    return to_vNx4char_t(in_val);
+}
+
+template <>
 MLI_FORCE_INLINE vNx4short_t mli_math_cast_fx(vNx4int_t in_val) {
+    in_val = mli_math_bound_range_fx(in_val, INT16_MIN, INT16_MAX);
     return to_vNx4short_t(in_val);
 }
 
 template <>
 MLI_FORCE_INLINE vNx2short_t mli_math_cast_fx(vNx2int_t in_val) {
+    in_val = mli_math_bound_range_fx(in_val, INT16_MIN, INT16_MAX);
     return to_vNx2short_t(in_val);
 }
 
 template <>
 MLI_FORCE_INLINE vNx4char_t mli_math_cast_fx(vNx4int_t in_val) {
     return to_vNx4char_t(mli_math_bound_range_fx(in_val, INT8_MIN, INT8_MAX));
+}
+
+template <>
+MLI_FORCE_INLINE vNx2short_t mli_math_cast_fx(vNx2int_t in_val, int shift_right) {
+    vNx2int_t r;
+#ifdef ROUND_UP
+    vNx2int_t round = ((1 << shift_right) >> 1);
+    r = mli_math_add_fx(in_val, round);
+    r = mli_math_asr_fx(r, shift_right);
+#else
+        #error Rounding mode not supported
+#endif
+
+    r = mli_math_bound_range_fx(r, INT16_MIN, INT16_MAX);
+
+    return to_vNx2short_t(r);
 }
 
 template<>
@@ -787,14 +953,15 @@ MLI_FORCE_INLINE vNx4short_t mli_math_cast_fx(vNx4short_t in_val, int shift_righ
     acc.lo = to_vNx2int_t(in_val.lo);
     acc.hi = to_vNx2int_t(in_val.hi);
     if (shift_right > 0) {
-        int round = 0;
 #ifdef ROUND_UP
         // Rounding up:
-        round = 1 << (shift_right - 1);
+        vNx4int_t round = 0;
+        round = ((1 << shift_right) >> 1);
+        acc = mli_math_add_fx(acc, round);
 #else
         #error Rounding mode not supported
 #endif
-        acc = (acc + round) >> shift_right;
+        acc = mli_math_asr_fx(acc, shift_right);
     } else {
         acc = (acc << (-shift_right));
     }
@@ -809,14 +976,15 @@ MLI_FORCE_INLINE vNx4char_t mli_math_cast_fx(vNx4short_t in_val, int shift_right
     acc.lo = to_vNx2int_t(in_val.lo);
     acc.hi = to_vNx2int_t(in_val.hi);
     if (shift_right > 0) {
-        int round = 0;
+        vNx4int_t round = 0;
 #ifdef ROUND_UP
-        // Rounding up:
-        round = 1 << (shift_right - 1);
+        // Rounding up
+        round = ((1 << shift_right) >> 1);
+        acc = mli_math_add_fx(acc, round);
+        acc = mli_math_asr_fx(acc, shift_right);
 #else
         #error Rounding mode not supported
 #endif
-        acc = (acc + round) >> shift_right;
     } else {
         acc = (acc << (-shift_right));
     }
@@ -974,8 +1142,8 @@ template<>
 MLI_FORCE_INLINE vNx4short_t mli_math_acc_cast_fx(vNx4accshort_t acc, int shift_right) {
 
 #ifdef ROUND_UP
-    int round = (1 << shift_right) >> 1;
-    acc = mli_math_add<vNx4accshort_t, vNx4short_t>(acc, (vNx4short_t)round);
+    vNx4short_t round = (1 << shift_right) >> 1;
+    acc = mli_math_add<vNx4accshort_t, vNx4short_t>(acc, round);
 #else
     #error Rounding mode not supported
 #endif
@@ -1471,6 +1639,18 @@ MLI_FORCE_INLINE vNx4short_t mli_math_select_fx(grp_pvNx2_t predicate, vNx4short
     res.lo = mli_math_select_fx<vNx2short_t, pvNx2>(predicate.lo, L.lo, R.lo);
     res.hi = mli_math_select_fx<vNx2short_t, pvNx2>(predicate.hi, L.hi, R.hi);
     return res;
+}
+
+template <typename in_T, typename acc_T>
+MLI_FORCE_INLINE acc_T mli_math_init_accu_sub(in_T L, in_T R) {
+    acc_T acc = vvcsub_init(L, R);
+    return acc;
+}
+
+template <typename in_T, typename acc_T>
+MLI_FORCE_INLINE acc_T mli_math_init_accu_add(in_T L, in_T R) {
+    acc_T acc = vvcadd_init(L, R);
+    return acc;
 }
 
 #endif // _VDSP_MLI_MATH_H_


### PR DESCRIPTION
- Vectorize eltwise_sub and eltwise_mul.
- Add eltwise_add/sub no guard bits implementation.
- Use saturating adds in rounding.