### PR TITLE
[sigm/tanh] optimize activation lut functions for vpx

### DIFF
--- a/lib/src/bricks/impl/mli_prv_lut_dsp.h
+++ b/lib/src/bricks/impl/mli_prv_lut_dsp.h
@@ -143,7 +143,7 @@ static MLI_FORCE_INLINE v2q15_t activation_lut_two_elem_no_interpolate(
 }
 
 template <typename io_T, bool convert>
-static void activation_lut(
+static MLI_FORCE_INLINE void compute_activation_lut(
         const struct generic_tensor_private_t<MLI_PTR(io_T)> *in,
         struct generic_tensor_private_t<MLI_PTR(io_T)> *out,
         const mli_lut *lut,
@@ -228,6 +228,7 @@ static void activation_lut(
         }
     }
 }
+
 } // namespace dsp
 } // namespace krn
 } // namespace mli

--- a/lib/src/bricks/mli_prv_lut.h
+++ b/lib/src/bricks/mli_prv_lut.h
@@ -25,21 +25,24 @@
 namespace mli {
 namespace krn {
 #if !defined(MLI_BUILD_REFERENCE) && defined(__Xvec_width)
-using mli::krn::vdsp::activation_lut;
+using mli::krn::vdsp::compute_activation_lut;
 using mli::krn::vdsp::activation_lut_vec_elem_interpolate;
 using mli::krn::vdsp::activation_lut_vec_elem_no_interpolate;
+using mli::krn::ref::activation_lut;
 using mli::krn::ref::activation_lut_one_elem_interpolate;
 using mli::krn::ref::activation_lut_one_elem_no_interpolate;
 
 #elif !defined(MLI_BUILD_REFERENCE) && defined(__FXAPI__)
-using mli::krn::dsp::activation_lut;
+using mli::krn::dsp::compute_activation_lut;
 using mli::krn::dsp::activation_lut_two_elem_interpolate;
 using mli::krn::dsp::activation_lut_two_elem_no_interpolate;
+using mli::krn::ref::activation_lut;
 using mli::krn::ref::activation_lut_one_elem_interpolate;
 using mli::krn::ref::activation_lut_one_elem_no_interpolate;
 
 #else
 using mli::krn::ref::activation_lut;
+using mli::krn::ref::compute_activation_lut;
 using mli::krn::ref::activation_lut_one_elem_interpolate;
 using mli::krn::ref::activation_lut_one_elem_no_interpolate;
 

--- a/lib/src/bricks/mli_prv_lut_decl.h
+++ b/lib/src/bricks/mli_prv_lut_decl.h
@@ -36,13 +36,31 @@ namespace krn {
 ////////////////////////////////////////////////////////////////////////////////
 namespace ref {
 template <typename io_T, bool convert = false>
-static void activation_lut(
+static MLI_FORCE_INLINE void activation_lut(
         const struct generic_tensor_private_t<MLI_PTR(io_T)> *in,
         struct generic_tensor_private_t<MLI_PTR(io_T)> *out,
         const mli_lut *lut,
         int8_t in_frac_bits,
         const struct s8asym_quant_params *in_params  = nullptr,
         struct s8asym_quant_params *out_params = nullptr);
+
+template <typename io_T, bool convert = false>
+static MLI_FORCE_INLINE void activation_lut(
+        const mli_tensor *in,
+        const mli_tensor *out,
+        const mli_lut *lut,
+        int in_frac_bits,
+        struct s8asym_quant_params *in_params = nullptr,
+        struct s8asym_quant_params *out_params = nullptr);
+
+template <typename io_T, bool convert>
+static MLI_FORCE_INLINE void compute_activation_lut(
+        const struct generic_tensor_private_t<MLI_PTR(io_T)> *in,
+        struct generic_tensor_private_t<MLI_PTR(io_T)> *out,
+        const mli_lut *lut,
+        int8_t in_frac_bits,
+        const struct s8asym_quant_params *in_params,
+        struct s8asym_quant_params *out_params);
 
 template <typename in_T, typename out_T, bool convert_input, bool convert_output>
 static MLI_FORCE_INLINE out_T activation_lut_one_elem_interpolate(
@@ -66,14 +84,15 @@ static MLI_FORCE_INLINE out_T activation_lut_one_elem_no_interpolate(
 // DSP
 ////////////////////////////////////////////////////////////////////////////////
 namespace dsp {
-template <typename io_T, bool convert = false>
-static void activation_lut(
+
+template <typename io_T, bool convert>
+static MLI_FORCE_INLINE void compute_activation_lut(
         const struct generic_tensor_private_t<MLI_PTR(io_T)> *in,
         struct generic_tensor_private_t<MLI_PTR(io_T)> *out,
         const mli_lut *lut,
         int8_t in_frac_bits,
-        const struct s8asym_quant_params *in_params  = nullptr,
-        struct s8asym_quant_params *out_params = nullptr);
+        const struct s8asym_quant_params *in_params,
+        struct s8asym_quant_params *out_params);
 
 #if !defined(MLI_BUILD_REFERENCE) && defined(__FXAPI__)
 template <typename out_T, bool convert_input, bool convert_output>
@@ -99,14 +118,15 @@ static MLI_FORCE_INLINE v2q15_t activation_lut_two_elem_no_interpolate(
 // VDSP
 ////////////////////////////////////////////////////////////////////////////////
 namespace vdsp {
-template <typename io_T, bool convert = false>
-static void activation_lut(
+
+template <typename io_T, bool convert>
+static MLI_FORCE_INLINE void compute_activation_lut(
         const struct generic_tensor_private_t<MLI_PTR(io_T)> *in,
-        struct generic_tensor_private_t<MLI_OUT_PTR(io_T)> *out,
+        struct generic_tensor_private_t<MLI_PTR(io_T)> *out,
         const mli_lut *lut,
         int8_t in_frac_bits,
-        const struct s8asym_quant_params *in_params  = nullptr,
-        struct s8asym_quant_params *out_params = nullptr);
+        const struct s8asym_quant_params *in_params,
+        struct s8asym_quant_params *out_params);
 
 #if !defined(MLI_BUILD_REFERENCE) && defined(__Xvec_width)
 template <bool convert>

--- a/lib/src/private/src/mli_prv_activation_lut.cc
+++ b/lib/src/private/src/mli_prv_activation_lut.cc
@@ -156,15 +156,7 @@ void mli_prv_activation_lut_fx8(
         const mli_tensor *out,
         const mli_lut *lut,
         int in_frac_bits) {
-
-    auto in_prv =  mli_prv_get_generic_tensor<MLI_PTR(int8_t)>(in);
-    auto out_prv =  mli_prv_get_generic_tensor<MLI_OUT_PTR(int8_t)>(out);
-
-    /* Reordering shapes/mem_stirde to place the inner most dim at last shape */
-    mli_prv_reorder_generic_tensor<MLI_PTR(int8_t)>(&in_prv );
-    mli_prv_reorder_generic_tensor<MLI_OUT_PTR(int8_t)>(&out_prv);
-
-    activation_lut<int8_t>(&in_prv, &out_prv, lut, in_frac_bits);
+    activation_lut<int8_t, /* convert = */ false>(in, out, lut, in_frac_bits);
 }
 
 void mli_prv_activation_lut_fx16(
@@ -172,15 +164,7 @@ void mli_prv_activation_lut_fx16(
         const mli_tensor *out,
         const mli_lut *lut,
         int in_frac_bits) {
-
-    auto in_prv =  mli_prv_get_generic_tensor<MLI_PTR(int16_t)>(in);
-    auto out_prv =  mli_prv_get_generic_tensor<MLI_OUT_PTR(int16_t)>(out);
-
-    /* Reordering shapes/mem_stirde to place the inner most dim at last shape */
-    mli_prv_reorder_generic_tensor<MLI_PTR(int16_t)>(&in_prv );
-    mli_prv_reorder_generic_tensor<MLI_OUT_PTR(int16_t)>(&out_prv);
-
-    activation_lut<int16_t>(&in_prv, &out_prv, lut, in_frac_bits);
+    activation_lut<int16_t, /* convert = */ false>(in, out, lut, in_frac_bits);
 }
 
 void mli_prv_activation_lut_sa8(
@@ -189,15 +173,7 @@ void mli_prv_activation_lut_sa8(
         const mli_lut *lut,
         struct s8asym_quant_params *in_params,
         struct s8asym_quant_params *out_params) {
-
-    auto in_prv =  mli_prv_get_generic_tensor<MLI_PTR(int8_t)>(in);
-    auto out_prv =  mli_prv_get_generic_tensor<MLI_OUT_PTR(int8_t)>(out);
-
-    /* Reordering shapes/mem_stirde to place the inner most dim at last shape */
-    mli_prv_reorder_generic_tensor<MLI_PTR(int8_t)>(&in_prv );
-    mli_prv_reorder_generic_tensor<MLI_OUT_PTR(int8_t)>(&out_prv);
-
-    activation_lut<int8_t, true>(&in_prv, &out_prv, lut, 0 /*Unused*/, in_params, out_params);
+    activation_lut<int8_t, /* convert = */ true>(in, out, lut, 0 /*Unused*/, in_params, out_params);
 }
 
 #pragma MLI_CODE_SECTION_END()


### PR DESCRIPTION
1. optimize activation lut functions for vpx (tanh/sigm kernels optimizations).
2. Squashed tensor dimensions as optimizations. 


- RID: 1143150