### PR TITLE
[prelu_opt]: Optimizing RELU/LeakyRelu

### DIFF
--- a/include/mli_config.h
+++ b/include/mli_config.h
@@ -72,7 +72,7 @@
 
 #if defined(__clang__)
 #define MLI_FORCE_INLINE inline __attribute__((always_inline))
-#define MLI_NO_INLINE __attribute__((noinline))
+#define MLI_NO_INLINE __attribute__((used)) __attribute__((noinline))
 #define MLI_CODE_SECTION_START(x) code(x) 
 #define MLI_CODE_SECTION_END()    code()
 

--- a/lib/src/kernels/transform/impl/mli_krn_leaky_relu_dsp.h
+++ b/lib/src/kernels/transform/impl/mli_krn_leaky_relu_dsp.h
@@ -1,0 +1,92 @@
+/*
+* Copyright 2021, Synopsys, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-3-Clause license found in
+* the LICENSE file in the root directory of this source tree.
+*
+*/
+
+#ifndef _MLI_KRN_LEAKY_RELU_DSP_H_
+#define _MLI_KRN_LEAKY_RELU_DSP_H_
+
+#include "mli_check.h"
+#include "mli_config.h"
+#include "mli_debug.h"
+#include "mli_helpers_api.h"
+#include "mli_math.h"
+#include "mli_prv_dsp.h"
+#include "mli_prv_tensor.h"
+#include "mli_types.h"
+
+namespace mli {
+namespace krn {
+namespace dsp {
+
+static MLI_FORCE_INLINE v2q15_t calc_leaky_relu(
+        const v2q15_t input,
+        const v2q15_t scale_v,
+        const int shift) {
+
+    /* out  = max(0, in) + alpha * min(0, in) */
+    v2q15_t zero = mli_prv_init_v<int16_t, v2q15_t>(0);
+    v2q15_t pos = mli_math_max_fx(zero, input);
+    v2q15_t neg = mli_math_acc_cast_fx<v2q15_t, v2accum40_t>(
+                  mli_math_mul_fx<v2q15_t, v2accum40_t>(scale_v, mli_math_min_fx(zero, input)), shift);
+    return mli_math_add_fx(pos, neg);
+}
+
+template <typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift) {
+
+    v2q15_t input = mli_prv_load_1vec(vec_in);
+    v2q15_t scale_v = mli_prv_init_v<io_T, v2q15_t>(scale);
+    mli_prv_store_n_samples(vec_out, calc_leaky_relu(input, scale_v, shift));
+}
+
+template <typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift,
+        const int remaining_part) {
+
+    MLI_ASSERT(remaining_part == 1);
+    v2q15_t input = mli_prv_load_1vec(vec_in);
+    v2q15_t scale_v = mli_prv_init_v<io_T, v2q15_t>(scale);
+    mli_prv_store_1_sample(vec_out, calc_leaky_relu(input, scale_v, shift));
+}
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params) {
+
+    mli::krn::ref::compute_leaky_relu(vec_in, vec_out, in_zp, identity_params, alpha_params);
+    mli::krn::ref::compute_leaky_relu(vec_in + 1, vec_out + 1, in_zp, identity_params, alpha_params);
+}
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int remaining_part) {
+
+    MLI_ASSERT(remaining_part == 1);
+    mli::krn::ref::compute_leaky_relu(vec_in, vec_out, in_zp, identity_params, alpha_params);
+}
+
+} // namespace dsp
+} // namespace krn
+} // namespace mli
+
+#endif // _MLI_KRN_LEAKY_RELU_DSP_H_

--- a/lib/src/kernels/transform/impl/mli_krn_leaky_relu_ref.h
+++ b/lib/src/kernels/transform/impl/mli_krn_leaky_relu_ref.h
@@ -1,0 +1,358 @@
+/*
+* Copyright 2021, Synopsys, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-3-Clause license found in
+* the LICENSE file in the root directory of this source tree.
+*
+*/
+
+#ifndef _MLI_KRN_LEAKY_RELU_REF_H_
+#define _MLI_KRN_LEAKY_RELU_REF_H_
+
+#include "mli_check.h"
+#include "mli_config.h"
+#include "mli_debug.h"
+#include "mli_helpers_api.h"
+#include "mli_math.h"
+#include "mli_prv_dsp.h"
+#include "mli_prv_tensor.h"
+#include "mli_prv_quant.h"
+#include "mli_types.h"
+
+namespace mli {
+namespace krn {
+namespace ref {
+
+template <typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift) {
+    io_T input = vec_in[0];
+    io_T zero = 0;
+    /* out  = max(0, in) + alpha * min(0, in) */
+    io_T pos = mli_math_max_fx(zero, input);
+    io_T neg = mli_math_acc_cast_fx<io_T, mli_acc32_t>(
+               mli_math_mul_fx<io_T, mli_acc32_t>( mli_math_min_fx(zero, input), scale), shift);
+    vec_out[0] = mli_math_add_fx(pos, neg);
+}
+
+template <typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift,
+        const int remaining_part) {
+
+    MLI_ASSERT(remaining_part == 1);
+    compute_leaky_relu<io_T>(vec_in, vec_out, scale, shift);
+}
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params) {
+
+    /* Load Input */
+    int8_t input = vec_in[0];
+    int16_t output;
+    if (input >= in_zp) {
+        /* out_sa8 = (idendity_scale * in_sa8) * 2^(-(identity_shift)) + identity_offset */
+        output =  mli_math_add_fx<int16_t>(
+                  mli_math_cast_fx<int32_t, int16_t>(
+                  mli_math_mul_fx<int16_t, int32_t>(identity_params->scale, input), 
+                  identity_params->shift), identity_params->offset);
+    } else {
+        /* out_sa8 = (alpha_scale * in_sa8) * 2^(-(alpha_shift)) + alpha_offset */
+        output =  mli_math_add_fx<int16_t>(
+                  mli_math_cast_fx<int32_t, int16_t>(
+                  mli_math_mul_fx<int16_t, int32_t>(alpha_params->scale, input), 
+                  alpha_params->shift), alpha_params->offset);
+    }
+    
+    vec_out[0] = mli_math_cast_fx<int16_t, int8_t>(output, 0);
+}
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int remaining_part) {
+
+    MLI_ASSERT(remaining_part == 1);
+    mli::krn::ref::compute_leaky_relu(vec_in, vec_out, in_zp, identity_params, alpha_params);
+}
+
+template<typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu_fx_inner_loop(
+        const MLI_PTR(io_T) __restrict vec_in,
+        MLI_OUT_PTR(io_T) __restrict vec_out,
+        const io_T scale,
+        const int shift,
+        const int count,
+        const int remaining_part) {
+    /* Dummy Load to get num_lanes */
+    auto input = mli_prv_load_1vec(vec_in);
+    int num_lanes = get_number_lanes(input);
+
+    if (remaining_part) {
+        mli::krn::compute_leaky_relu<io_T>(vec_in, vec_out, scale,
+                                            shift, remaining_part);
+        vec_in  += remaining_part;
+        vec_out += remaining_part;
+    }
+    for (int pos3 = remaining_part; pos3 < count; pos3 += num_lanes) {
+        mli::krn::compute_leaky_relu<io_T>(vec_in, vec_out, scale, shift);
+        vec_in  += num_lanes;
+        vec_out += num_lanes;
+    }
+}
+
+static MLI_FORCE_INLINE void compute_leaky_relu_sa8_inner_loop(
+        const MLI_PTR(int8_t) __restrict vec_in,
+        MLI_OUT_PTR(int8_t) __restrict vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int count,
+        const int remaining_part) {
+    /* Dummy Load to get num_lanes */
+    auto input = mli_prv_load_1vec(vec_in);
+    int num_lanes = get_number_lanes(input);
+
+    if (remaining_part) {
+        mli::krn::compute_leaky_relu(vec_in, vec_out, in_zp, identity_params, alpha_params, remaining_part);
+        vec_in  += remaining_part;
+        vec_out += remaining_part;
+    }
+
+    for (int pos3 = remaining_part; pos3 < count; pos3 += num_lanes) {
+        mli::krn::compute_leaky_relu(vec_in, vec_out, in_zp, identity_params, alpha_params);
+        vec_in  += num_lanes;
+        vec_out += num_lanes;
+    }
+}
+
+template <typename io_T>
+static MLI_FORCE_INLINE mli_status leaky_relu_fx_run(const mli_tensor *in,
+        const mli_tensor *slope_coeff,
+        mli_tensor *out) {
+
+    mli_prv_fx_init_dsp_ctrl();
+
+    const MLI_PTR(io_T) __restrict in_ptr = mli_prv_tensor_data_ptr<MLI_PTR(io_T)>(in);
+    MLI_OUT_PTR(io_T) __restrict out_ptr  = mli_prv_tensor_data_ptr<MLI_OUT_PTR(io_T)>(out);
+
+    /* Copy tensor format */
+    mli_prv_copy_tensor_format_except_mem_strides(in, out);
+
+    /* Dummy Load to get num_lanes */
+    auto input = mli_prv_load_1vec(in_ptr);
+    int num_lanes = get_number_lanes(input);
+    int remaining_part = 0;
+
+    int shift = mli_prv_calc_shift(in, slope_coeff, out);
+    io_T scale = mli_prv_tensor_data_val<io_T>(slope_coeff);
+
+    int shift_val = shift;
+    if (std::is_same<io_T, int16_t>::value) {
+        /* Normalization is needed for int16_t as we use mul_hi */
+        int norm_shift;
+        scale = mli_math_norm_cast_fx<io_T,io_T>(scale, &norm_shift);
+        shift_val -= norm_shift;
+    }
+
+    /* Trying to squash tensor to one dim */
+    int shape = mli_prv_squash_tensor_to_one_dim(in, out);
+    if (shape) {
+        remaining_part = shape & (num_lanes - 1);
+        mli::krn::compute_leaky_relu_fx_inner_loop(in_ptr, out_ptr, scale, 
+                                shift_val, shape, remaining_part);
+    } else {
+        /* Get Generic Private Tensor */
+        auto in_prv =  mli_prv_get_generic_tensor<MLI_PTR(io_T)>(in);
+        auto out_prv = mli_prv_get_generic_tensor<MLI_OUT_PTR(io_T)>(out);
+        /* Reordering shapes/mem_stirde to place the inner most dim at last shape */
+        mli_prv_squash_generic_tensor<MLI_PTR(io_T)>(&in_prv, &out_prv);
+
+        remaining_part = in_prv.shape[3] & (num_lanes - 1);
+        /* Loop Over Sub Tensor */
+        const MLI_PTR(io_T) __restrict orig_vec_in = in_ptr;
+        MLI_OUT_PTR(io_T) __restrict orig_vec_out = out_ptr;
+        for (int pos0 = 0; pos0 < in_prv.shape[0]; pos0++) {
+            for (int pos1 = 0; pos1 < in_prv.shape[1]; pos1++) {
+                for (int pos2 = 0; pos2 < in_prv.shape[2]; pos2++) {
+                    in_ptr  = (MLI_PTR(io_T))orig_vec_in  + POS(&in_prv, pos0, pos1, pos2, 0);
+                    out_ptr = orig_vec_out + POS(&out_prv, pos0, pos1, pos2, 0);
+                    mli::krn::compute_leaky_relu_fx_inner_loop(in_ptr, out_ptr, scale, 
+                                                          shift_val, in_prv.shape[3], remaining_part);
+                }
+            }
+        }
+    }
+
+    return MLI_STATUS_OK;
+}
+
+static MLI_FORCE_INLINE s8asym_quant_params leaky_relu_define_requant_params(const mli_tensor *in, 
+        const mli_tensor *slope_coeff,
+        mli_tensor *out,
+        const int8_t alpha_sa8,
+        const s8asym_quant_params *identity_params) {
+    
+    /* ****************************************************************************************************************
+     *             Mathematical Derivations out_sa8 Requantization Params with alpha scale to use with in_sa8
+     * ----------------------------------------------------------------------------------------------------------------
+     *      First we need to define Quantization Params for In/Out 
+     *          out_sa8 = (in_scale_val/out_scale_val) *(in_sa8 - in_zp) + out_zp
+     *      where we define scale, scale_shift and offset modified values
+     *          check -> define_quant_params(const mli_tensor *in, const mli_tensor *out, s8asym_quant_params *params)
+     *          for Documentation
+     *      then :
+     * 
+     *      out_sa8 = (in_scale_val/out_scale_val) * alpha_scale * (alpha_sa8 - alpha_zp) * (in_sa8 - in_zp) + out_zp
+     *              = scale_val * alpha_val * (alpha_sa8 - alpha_zp) * (in_sa8 - in_zp) + out_zp
+     *              = scale_alpha_val * (in_sa8 - in_zp) + out_zp
+     *              = scale_alpha_val * in_sa8 + out_zp - scale_alpha_val * in_zp
+     *              = scale_alpha_val * in_sa8 + scale_alpha_offset;
+     * 
+     *      For scale_alpha_val = scale_val * alpha_val * (alpha_sa8 - alpha_zp) 
+     *                        = scale * 2 ^(-(scale_shift)) * alpha_scale 
+     *                          * 2^(-alpha_scale_frac_bits) * (alpha_sa8 - alpha_zp)
+     *                        = scale * alpha_scale * (alpha_sa8 - alpha_zp) 
+     *                          * 2^(-(scale_shift + alpha_scale_frac_bits))
+     *                        = scale * alpha_scale * (alpha_sa8 - alpha_zp) * 2^(-(alpha_norm_shift))
+     *                          * 2^(-(scale_shift + alpha_scale_frac_bits - alpha_norm_shift))
+     *                        = scale * alpha
+     *                          * 2^(-(scale_shift + alpha_scale_frac_bits - alpha_norm_shift))
+     *                        = scale * alpha * 2^(-(scale_mul_norm_shift))
+     *                          * 2^(-(scale_shift + alpha_scale_frac_bits - alpha_norm_shift - scale_mul_norm_shift))
+     *                        = scale_alpha * 2^(-(scale_alpha_shift))
+     * 
+     *      where alpha = alpha_scale * (alpha_sa8 - alpha_zp) * 2^(-(alpha_norm_shift))
+     *            alpha_norm_shift is the shift value due to normalizing the result of 
+     *                             alpha_scale * (alpha_sa8 - alpha_zp) and casting it from int32_t to int16_t
+     *            scale_alpha = scale * alpha * 2^(-(scale_mul_norm_shift))
+     *            scale_mul_norm_shift is the shift value due to normalizing the result of 
+     *                             scale * alpha_scale * (alpha_sa8 - alpha_zp) * 2^(-(alpha_norm_shift))
+     *            scale_alpha_shift = scale_shift + alpha_scale_frac_bits - alpha_norm_shift - scale_mul_norm_shift
+     * 
+     *      scale_alpha_offset = out_zp - scale_alpha_val * in_zp
+     *                         = out_zp - (scale_alpha * in_zp) * 2^(-(scale_alpha_shift));
+     * 
+     * ***************************************************************************************************************/
+
+    int32_t alpha_val = mli_prv_convert_sa8_fx16<int8_t, int32_t>(alpha_sa8, 
+                            slope_coeff->el_params.sa.zero_point.mem.i16,
+                            slope_coeff->el_params.sa.scale.mem.i16);
+    /* Normalize alpha and cast to 16bit */
+    int norm_shift;
+    int16_t alpha = mli_math_norm_cast_fx<int32_t,int16_t>(alpha_val, &norm_shift);
+    
+    int scale_alpha_shift  = identity_params->shift;
+        scale_alpha_shift += slope_coeff->el_params.sa.scale_frac_bits.mem.i8;
+        scale_alpha_shift -= norm_shift;
+    
+    int16_t scale_alpha = mli_math_norm_cast_fx<int32_t,int16_t>(
+                          mli_math_mul_fx<int16_t, int32_t>(identity_params->scale, alpha), &norm_shift);
+    scale_alpha_shift -= norm_shift;
+
+    int16_t in_zp  = in->el_params.sa.zero_point.mem.i16;
+    int16_t out_zp = out->el_params.sa.zero_point.mem.i16;
+    
+    int16_t scale_alpha_offset = mli_math_sub_fx<int16_t>(out_zp,
+                                 mli_math_cast_fx<int32_t, int16_t>(
+                                 mli_math_mul_fx<int16_t, int32_t>(scale_alpha, in_zp), scale_alpha_shift));
+    
+    /* Define Quantization params for (In * alpha / out) ratio */
+    s8asym_quant_params alpha_params;
+    alpha_params.scale  = scale_alpha;
+    alpha_params.shift  = scale_alpha_shift;
+    alpha_params.offset = scale_alpha_offset;
+    return alpha_params;
+}
+
+static MLI_FORCE_INLINE mli_status leaky_relu_sa8_run(const mli_tensor *in, 
+        const mli_tensor *slope_coeff,
+        mli_tensor *out) {
+
+    mli_prv_fx_init_dsp_ctrl();
+
+    const MLI_PTR(int8_t) in_ptr = mli_prv_tensor_data_ptr<MLI_PTR(int8_t)>(in);
+    MLI_OUT_PTR(int8_t) out_ptr = mli_prv_tensor_data_ptr<MLI_OUT_PTR(int8_t)>(out);
+
+    /* Copy tensor format */
+    for (int idx = 0; idx < (int)in->rank; idx++) {
+        out->shape[idx] = in->shape[idx];
+    }
+    out->rank = in->rank;
+    out->el_type = in->el_type;
+
+    /* Input Zero Point */
+    int16_t in_zp = in->el_params.sa.zero_point.mem.i16;
+    int8_t scale = mli_prv_tensor_data_val<int8_t>(slope_coeff);
+
+    /* ****************************************************************************************************************
+     *                        Mathematical Derivations for Leaky RELU SA8 
+     * ----------------------------------------------------------------------------------------------------------------
+     *    If (in_sa8 >= in_zp)
+     *       out_sa8 = (idendity_scale * in_sa8) * 2^(-(identity_shift)) + identity_offset; 
+     *    else
+     *       out_sa8 = (alpha_scale * in_sa8) * 2^(-(alpha_shift)) + alpha_offset;
+     * 
+     *    check leaky_relu_define_requant_params for more Documentation
+     * ***************************************************************************************************************/
+    s8asym_quant_params identity_params;
+    /* Define Requantization Params for In/Out scale ratio */
+    define_requant_params(in, out, &identity_params);
+    s8asym_quant_params alpha_params = leaky_relu_define_requant_params(in, slope_coeff, out, scale, &identity_params);
+
+    /* Dummy Load to get num_lanes */
+    auto input = mli_prv_load_1vec(in_ptr);
+    int num_lanes = get_number_lanes(input);
+    int remaining_part = 0;
+
+    /* Trying to squash tensor to one dim */
+    int shape = mli_prv_squash_tensor_to_one_dim(in, out);
+    if (shape) {
+        remaining_part = shape & (num_lanes - 1);
+        mli::krn::compute_leaky_relu_sa8_inner_loop(in_ptr, out_ptr, in_zp, &identity_params, &alpha_params,
+                                                   shape, remaining_part);
+    } else {
+        /* Get Generic Private Tensor */
+        auto in_prv =  mli_prv_get_generic_tensor<MLI_PTR(int8_t)>(in);
+        auto out_prv = mli_prv_get_generic_tensor<MLI_OUT_PTR(int8_t)>(out);
+        /* Reordering shapes/mem_stirde to place the inner most dim at last shape */
+        mli_prv_squash_generic_tensor<MLI_PTR(int8_t)>(&in_prv, &out_prv);
+
+        remaining_part = in_prv.shape[3] & (num_lanes - 1);
+        /* Loop Over Sub Tensor */
+        const MLI_PTR(int8_t) __restrict orig_vec_in = in_ptr;
+        MLI_OUT_PTR(int8_t) __restrict orig_vec_out = out_ptr;
+        for (int pos0 = 0; pos0 < in_prv.shape[0]; pos0++) {
+            for (int pos1 = 0; pos1 < in_prv.shape[1]; pos1++) {
+                for (int pos2 = 0; pos2 < in_prv.shape[2]; pos2++) {
+                    in_ptr  = (MLI_PTR(int8_t))orig_vec_in  + POS(&in_prv, pos0, pos1, pos2, 0);
+                    out_ptr = orig_vec_out + POS(&out_prv, pos0, pos1, pos2, 0);
+                    mli::krn::compute_leaky_relu_sa8_inner_loop(in_ptr, out_ptr, in_zp, &identity_params, &alpha_params,
+                                                               in_prv.shape[3], remaining_part);
+                }
+            }
+        }
+    }
+
+    return MLI_STATUS_OK;
+}
+
+} // namespace ref
+} // namespace krn
+} // namespace mli
+
+#endif // _MLI_KRN_LEAKY_RELU_REF_H_

--- a/lib/src/kernels/transform/impl/mli_krn_leaky_relu_vdsp.h
+++ b/lib/src/kernels/transform/impl/mli_krn_leaky_relu_vdsp.h
@@ -1,0 +1,192 @@
+/*
+* Copyright 2021, Synopsys, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-3-Clause license found in
+* the LICENSE file in the root directory of this source tree.
+*
+*/
+
+#ifndef _MLI_KRN_LEAKY_RELU_VDSP_H_
+#define _MLI_KRN_LEAKY_RELU_VDSP_H_
+
+#include "mli_check.h"
+#include "mli_config.h"
+#include "mli_debug.h"
+#include "mli_helpers_api.h"
+#include "mli_math.h"
+#include "mli_prv_dsp.h"
+#include "mli_prv_tensor.h"
+#include "mli_types.h"
+
+namespace mli {
+namespace krn {
+namespace vdsp {
+
+static MLI_FORCE_INLINE vNx4char_t calc_leaky_relu(
+        const vNx4char_t input,
+        const int8_t scale,
+        const int shift ) {
+    pvNx4 sel = init_predicate(input > 0);
+    vNx4accshort_t acc = mli_math_mul_fx<vNx4char_t, vNx4accshort_t>(input, scale);
+    vNx4char_t neg = mli_math_acc_cast_fx<vNx4char_t, vNx4accshort_t>(acc, shift);
+
+    return mli_math_select_fx(sel, input, neg);
+}
+
+static MLI_FORCE_INLINE vNx2short_t calc_leaky_relu(
+        const vNx2short_t input,
+        const int16_t scale,
+        const int shift ) {
+
+    constexpr int mul_hi_shift = 16;
+    pvNx2 sel = init_predicate(input > 0);
+    vNx2short_t neg;
+    if ( shift > mul_hi_shift) {
+    	neg = mli_math_mul_fx_high(input, scale);
+    	neg = mli_math_asr_rnd_fx(neg, shift - mul_hi_shift);
+    } else {
+    	vNx2accint_t acc = mli_math_mul_fx<vNx2short_t, vNx2accint_t>(input, scale);
+    	neg = mli_math_acc_cast_fx<vNx2short_t, vNx2accint_t>(acc, shift);
+    }
+
+    return mli_math_select_fx(sel, input, neg);
+}
+
+template<typename io_T>
+MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift) {
+
+    auto input = mli_prv_load_1vec(vec_in);
+    mli_prv_store_n_samples(vec_out, calc_leaky_relu(input, scale, shift));
+}
+
+template<typename io_T>
+MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift,
+        const int remaining_part) {
+
+    auto input = mli_prv_load_1vec(vec_in);
+    mli_prv_store_n_samples(vec_out, calc_leaky_relu(input, scale, shift), remaining_part);
+}
+
+template<typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu_fx_inner_loop(
+        const MLI_PTR(io_T) __restrict vec_in,
+        MLI_OUT_PTR(io_T) __restrict vec_out,
+        const io_T scale,
+        const int shift,
+        const int count,
+        const int remaining_part) {
+    /* Dummy Load to get num_lanes */
+    auto input = mli_prv_load_1vec(vec_in);
+    int num_lanes = get_number_lanes(input);
+
+    if (remaining_part) {
+        compute_leaky_relu<io_T>(vec_in, vec_out, scale, shift, remaining_part);
+        vec_in  += remaining_part;
+        vec_out += remaining_part;
+    }
+
+#pragma clang loop unroll_count(4)
+    for (int pos3 = remaining_part; pos3 < count; pos3 += num_lanes) {
+        compute_leaky_relu<io_T>(vec_in, vec_out, scale, shift);
+        vec_in  += num_lanes;
+        vec_out += num_lanes;
+    }
+}
+
+static MLI_FORCE_INLINE vNx4char_t calc_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params) {
+    /* Load Input */
+    vNx4char_t input = mli_prv_load_1vec(vec_in);
+    vNx4short_t input_cast = mli_math_cast_fx<vNx4char_t, vNx4short_t>(input);
+    grp_pvNx2_t select = init_predicate_grp(input_cast >= in_zp);
+
+    int identity_shift = identity_params->shift;
+    int identity_shift_left  = mli_math_max_fx(-identity_shift, 0);
+    int identity_shift_right = mli_math_max_fx(identity_shift, 0);
+    vNx4int_t input_identity_scale = mli_math_mul_fx<vNx4short_t, vNx4int_t>(identity_params->scale, input_cast);
+              input_identity_scale = mli_math_asl_fx(input_identity_scale, identity_shift_left);
+              input_identity_scale = mli_math_asr_rnd_fx(input_identity_scale, identity_shift_right);
+
+    vNx4short_t output_identity = mli_math_cast_fx<vNx4int_t, vNx4short_t>(input_identity_scale);
+                output_identity = mli_math_add_fx(output_identity, (vNx4short_t)identity_params->offset);
+
+    int alpha_shift = alpha_params->shift;
+    int alpha_shift_left = mli_math_max_fx(-alpha_shift, 0);
+    int alpha_shift_right = mli_math_max_fx(alpha_shift, 0);
+    vNx4int_t input_alpha_scale = mli_math_mul_fx<vNx4short_t, vNx4int_t>(input_cast, alpha_params->scale);
+              input_alpha_scale = mli_math_asl_fx(input_alpha_scale, alpha_shift_left);
+              input_alpha_scale = mli_math_asr_rnd_fx(input_alpha_scale, alpha_shift_right);
+
+    vNx4short_t output_alpha = mli_math_cast_fx<vNx4int_t, vNx4short_t>(input_alpha_scale);
+                output_alpha = mli_math_add_fx(output_alpha, (vNx4short_t)alpha_params->offset);
+    
+    vNx4short_t output = mli_math_select_fx(select, output_identity, output_alpha);
+    return mli_math_cast_fx<vNx4short_t, vNx4char_t>(output);
+}
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params) {
+
+    vNx4char_t output = calc_leaky_relu(vec_in, in_zp, identity_params, alpha_params);
+    mli_prv_store_n_samples(vec_out, output);
+}
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int remaining_part) {
+
+    vNx4char_t output = calc_leaky_relu(vec_in, in_zp, identity_params, alpha_params);
+    mli_prv_store_n_samples(vec_out, output, remaining_part);
+}
+
+static MLI_FORCE_INLINE void compute_leaky_relu_sa8_inner_loop(
+        const MLI_PTR(int8_t) __restrict vec_in,
+        MLI_OUT_PTR(int8_t) __restrict vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int count,
+        const int remaining_part) {
+
+    /* Dummy Load to get num_lanes */
+    auto input = mli_prv_load_1vec(vec_in);
+    int num_lanes = get_number_lanes(input);
+
+    if (remaining_part) {
+        compute_leaky_relu(vec_in, vec_out, in_zp, identity_params, alpha_params, remaining_part);
+        vec_in  += remaining_part;
+        vec_out += remaining_part;
+    }
+
+    for (int pos3 = remaining_part; pos3 < count; pos3 += num_lanes) {
+        compute_leaky_relu(vec_in, vec_out, in_zp, identity_params, alpha_params);
+        vec_in  += num_lanes;
+        vec_out += num_lanes;
+    }
+}
+
+} // namespace vdsp
+} // namespace krn
+} // namespace mli
+
+#endif // _MLI_KRN_LEAKY_RELU_VDSP_H_

--- a/lib/src/kernels/transform/impl/mli_krn_relu_ref.h
+++ b/lib/src/kernels/transform/impl/mli_krn_relu_ref.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2020, Synopsys, Inc.
+* Copyright 2020-2021, Synopsys, Inc.
 * All rights reserved.
 *
 * This source code is licensed under the BSD-3-Clause license found in
@@ -23,59 +23,75 @@ namespace mli {
 namespace krn {
 namespace ref {
 
+template<typename io_T>
+static MLI_FORCE_INLINE void compute_relu_inner_loop(
+        const MLI_PTR(io_T) __restrict vec_in,
+        MLI_OUT_PTR(io_T) __restrict vec_out,
+        const io_T min_val,
+        const io_T max_val,
+        const int count) {
+    /* Dummy Load to get num_lanes, remaining part */
+    auto input = mli_prv_load_1vec(vec_in);
+    int num_lanes = get_number_lanes(input);
+    int remaining_part = count & (num_lanes - 1);
+
+    if (remaining_part) {
+        input = mli_prv_load_1vec(vec_in);
+        mli_prv_store_n_samples(vec_out, mli_math_min_fx(
+            mli_math_max_fx(input, min_val), max_val), remaining_part);
+        vec_in  += remaining_part;
+        vec_out += remaining_part;
+    }
+    for (int pos3 = remaining_part; pos3 < count; pos3 += num_lanes) {
+        input = mli_prv_load_1vec(vec_in);
+        mli_prv_store_n_samples(vec_out, mli_math_min_fx(
+            mli_math_max_fx(input, min_val), max_val));
+        vec_in  += num_lanes;
+        vec_out += num_lanes;
+    }
+}
+
 template <typename io_T, bool asym>
 static MLI_FORCE_INLINE mli_status mli_krn_relu_fx_run(const mli_tensor *in, 
         const mli_relu_cfg *cfg, mli_tensor *out) {
 
     mli_prv_fx_init_dsp_ctrl();
     
-    const MLI_PTR(io_T) vec_in = mli_prv_tensor_data_ptr<MLI_PTR(io_T)>(in);
-    MLI_OUT_PTR(io_T) vec_out = mli_prv_tensor_data_ptr<MLI_OUT_PTR(io_T)>(out);
+    const MLI_PTR(io_T) __restrict vec_in = mli_prv_tensor_data_ptr<MLI_PTR(io_T)>(in);
+    MLI_OUT_PTR(io_T) __restrict vec_out = mli_prv_tensor_data_ptr<MLI_OUT_PTR(io_T)>(out);
 
     /* Copy tensor format */
     mli_prv_copy_tensor_format_except_mem_strides(in, out);
-    /* Get Generic Private Tensor */
-    auto in_prv =  mli_prv_get_generic_tensor<MLI_PTR(io_T)>(in);
-    auto out_prv = mli_prv_get_generic_tensor<MLI_OUT_PTR(io_T)>(out);
-    /* Reordering shapes/mem_stirde to place the inner most dim at last shape */
-    mli_prv_reorder_generic_tensor<MLI_PTR(io_T)>(&in_prv );
-    mli_prv_reorder_generic_tensor<MLI_OUT_PTR(io_T)>(&out_prv);
 
-    /* Dummy Load to get num_lanes, remaining part */
-    auto input = mli_prv_load_1vec(vec_in);
-    int num_lanes = get_number_lanes(input);
-    int remaining_part = in_prv.shape[3] & (num_lanes - 1);
-
-    const MLI_PTR(io_T) orig_vec_in = vec_in;
-    MLI_OUT_PTR(io_T) orig_vec_out = vec_out;
-    
+    /* Get Relu Limits */
     const mli_minmax_t limits = mli_prv_get_relu_limits<io_T, asym>(cfg, in);
     const io_T min_val = static_cast<io_T>(limits.min);
     const io_T max_val = static_cast<io_T>(limits.max);
 
-    for (int pos0 = 0; pos0 < in_prv.shape[0]; pos0++) {
-        for (int pos1 = 0; pos1 < in_prv.shape[1]; pos1++) {
-            for (int pos2 = 0; pos2 < in_prv.shape[2]; pos2++) {
-                vec_in  = (MLI_PTR(io_T))orig_vec_in + POS(&in_prv,  pos0, pos1, pos2, 0);
-                vec_out = orig_vec_out + POS(&out_prv, pos0, pos1, pos2, 0);
-                if (remaining_part) {
-                    input = mli_prv_load_1vec(vec_in);
-                    mli_prv_store_n_samples(vec_out, mli_math_min_fx( 
-                        mli_math_max_fx(input, min_val), max_val), remaining_part);
-                    vec_in  += remaining_part;
-                    vec_out += remaining_part;
-                }
-                for (int pos3 = remaining_part; pos3 < in_prv.shape[3]; pos3 += num_lanes) {
-                    input = mli_prv_load_1vec(vec_in);
-                    mli_prv_store_n_samples(vec_out, mli_math_min_fx( 
-                        mli_math_max_fx(input, min_val), max_val));
-                    vec_in  += num_lanes;
-                    vec_out += num_lanes;
+    int shape = mli_prv_squash_tensor_to_one_dim(in, out);
+
+    if(shape) {
+        mli::krn::compute_relu_inner_loop<io_T>(vec_in, vec_out, min_val, max_val, shape);
+    } else {
+        /* Get Generic Private Tensor */
+        auto in_prv =  mli_prv_get_generic_tensor<MLI_PTR(io_T)>(in);
+        auto out_prv = mli_prv_get_generic_tensor<MLI_OUT_PTR(io_T)>(out);
+        /* Reordering shapes/mem_stirde to place the inner most dim at last shape */
+        mli_prv_squash_generic_tensor<MLI_PTR(io_T)>(&in_prv, &out_prv);
+
+        const MLI_PTR(io_T) __restrict orig_vec_in = vec_in;
+        MLI_OUT_PTR(io_T) __restrict orig_vec_out = vec_out;
+
+        for (int pos0 = 0; pos0 < in_prv.shape[0]; pos0++) {
+            for (int pos1 = 0; pos1 < in_prv.shape[1]; pos1++) {
+                for (int pos2 = 0; pos2 < in_prv.shape[2]; pos2++) {
+                    vec_in  = (MLI_PTR(io_T))orig_vec_in + POS(&in_prv,  pos0, pos1, pos2, 0);
+                    vec_out = orig_vec_out + POS(&out_prv, pos0, pos1, pos2, 0);
+                    mli::krn::compute_relu_inner_loop<io_T>(vec_in, vec_out, min_val, max_val, in_prv.shape[3]);
                 }
             }
         }
     }
-
     return MLI_STATUS_OK;
 }
 

--- a/lib/src/kernels/transform/impl/mli_krn_relu_vdsp.h
+++ b/lib/src/kernels/transform/impl/mli_krn_relu_vdsp.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2020, Synopsys, Inc.
+* Copyright 2020-2021, Synopsys, Inc.
 * All rights reserved.
 *
 * This source code is licensed under the BSD-3-Clause license found in
@@ -22,6 +22,35 @@
 namespace mli {
 namespace krn {
 namespace vdsp {
+
+template<typename io_T>
+static MLI_FORCE_INLINE void compute_relu_inner_loop(
+        const MLI_PTR(io_T) __restrict vec_in,
+        MLI_OUT_PTR(io_T) __restrict vec_out,
+        const io_T min_val,
+        const io_T max_val,
+        const int count) {
+    /* Dummy Load to get num_lanes, remaining part */
+    auto input = mli_prv_load_1vec(vec_in);
+    int num_lanes = get_number_lanes(input);
+    int remaining_part = count & (num_lanes - 1);
+
+    if (remaining_part) {
+        input = mli_prv_load_1vec(vec_in);
+        mli_prv_store_n_samples(vec_out, mli_math_min_fx(
+            mli_math_max_fx(input, min_val), max_val), remaining_part);
+        vec_in  += remaining_part;
+        vec_out += remaining_part;
+    }
+#pragma clang loop unroll_count(4)
+    for (int pos3 = remaining_part; pos3 < count; pos3 += num_lanes) {
+        input = mli_prv_load_1vec(vec_in);
+        mli_prv_store_n_samples(vec_out, mli_math_min_fx(
+            mli_math_max_fx(input, min_val), max_val));
+        vec_in  += num_lanes;
+        vec_out += num_lanes;
+    }
+}
 
 } // namespace vdsp
 } // namespace krn

--- a/lib/src/kernels/transform/mli_krn_leaky_relu.h
+++ b/lib/src/kernels/transform/mli_krn_leaky_relu.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2020-2021, Synopsys, Inc.
+* Copyright 2021, Synopsys, Inc.
 * All rights reserved.
 *
 * This source code is licensed under the BSD-3-Clause license found in
@@ -7,10 +7,10 @@
 *
 */
 
-#ifndef _MLI_KRN_RELU_H_
-#define _MLI_KRN_RELU_H_
+#ifndef _MLI_KRN_LEAKY_RELU_H_
+#define _MLI_KRN_LEAKY_RELU_H_
 
-#include "mli_krn_relu_decl.h"
+#include "mli_krn_leaky_relu_decl.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Setting up namespace
@@ -23,16 +23,25 @@
 namespace mli {
 namespace krn {
 #if !defined(MLI_BUILD_REFERENCE) && defined(__Xvec_width)
-using mli::krn::vdsp::compute_relu_inner_loop;
-using mli::krn::ref::mli_krn_relu_fx_run;
+using mli::krn::vdsp::compute_leaky_relu;
+using mli::krn::vdsp::compute_leaky_relu_fx_inner_loop;
+using mli::krn::vdsp::compute_leaky_relu_sa8_inner_loop;
+using mli::krn::ref::leaky_relu_fx_run;
+using mli::krn::ref::leaky_relu_sa8_run;
 
 #elif !defined(MLI_BUILD_REFERENCE) && defined(__FXAPI__)
-using mli::krn::ref::compute_relu_inner_loop;
-using mli::krn::ref::mli_krn_relu_fx_run;
+using mli::krn::dsp::compute_leaky_relu;
+using mli::krn::ref::compute_leaky_relu_fx_inner_loop;
+using mli::krn::ref::compute_leaky_relu_sa8_inner_loop;
+using mli::krn::ref::leaky_relu_fx_run;
+using mli::krn::ref::leaky_relu_sa8_run;
 
 #else
-using mli::krn::ref::compute_relu_inner_loop;
-using mli::krn::ref::mli_krn_relu_fx_run;
+using mli::krn::ref::compute_leaky_relu;
+using mli::krn::ref::compute_leaky_relu_fx_inner_loop;
+using mli::krn::ref::compute_leaky_relu_sa8_inner_loop;
+using mli::krn::ref::leaky_relu_fx_run;
+using mli::krn::ref::leaky_relu_sa8_run;
 
 #endif
 } // namespace krn
@@ -45,14 +54,14 @@ using mli::krn::ref::mli_krn_relu_fx_run;
 // included. Other variants are included based on capabilities. Implementations
 // below can depend on each other through declarations in *_decl.h.
 
-#include "impl/mli_krn_relu_ref.h"
+#include "impl/mli_krn_leaky_relu_ref.h"
 
 #if !defined(MLI_BUILD_REFERENCE) && defined(__Xvec_width)
-#include "impl/mli_krn_relu_vdsp.h"
+#include "impl/mli_krn_leaky_relu_vdsp.h"
 #endif
 
 #if !defined(MLI_BUILD_REFERENCE) && defined(__FXAPI__)
-#include "impl/mli_krn_relu_dsp.h"
+#include "impl/mli_krn_leaky_relu_dsp.h"
 #endif
 
-#endif // _MLI_KRN_RELU_H_
+#endif // _MLI_KRN_LEAKY_RELU_H_

--- a/lib/src/kernels/transform/mli_krn_leaky_relu_decl.h
+++ b/lib/src/kernels/transform/mli_krn_leaky_relu_decl.h
@@ -1,0 +1,186 @@
+/*
+* Copyright 2021, Synopsys, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-3-Clause license found in
+* the LICENSE file in the root directory of this source tree.
+*
+*/
+
+#ifndef _MLI_KRN_LEAKY_RELU_DECL_H_
+#define _MLI_KRN_LEAKY_RELU_DECL_H_
+
+#include "mli_config.h"
+#include "mli_types.h"
+#include "mli_prv_tensor.h"
+#include "mli_prv_quant.h"
+
+namespace mli {
+namespace krn {
+////////////////////////////////////////////////////////////////////////////////
+// Functions (in *_ref/*_dsp/*vdsp) that can be called from outside their own
+// file must be declared here. This includes all overloads. For example, if we
+// have: io_T f(io_T a) and int8_t f(int8_t a), then both must be declared.
+// Not doing so, can cause the compiler to use the wrong overload.
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+// REF
+////////////////////////////////////////////////////////////////////////////////
+namespace ref {
+
+template <typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift);
+
+template <typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift,
+        const int remaining_part);
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params);
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int remaining_part);
+
+template<typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu_fx_inner_loop(
+        const MLI_PTR(io_T) __restrict vec_in,
+        MLI_OUT_PTR(io_T) __restrict vec_out,
+        const io_T scale,
+        const int shift,
+        const int count,
+        const int remaining_part);
+
+static MLI_FORCE_INLINE void compute_leaky_relu_sa8_inner_loop(
+        const MLI_PTR(int8_t) __restrict vec_in,
+        MLI_OUT_PTR(int8_t) __restrict vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int count,
+        const int remaining_part);
+
+template <typename io_T>
+static MLI_FORCE_INLINE mli_status leaky_relu_fx_run(const mli_tensor *in,
+        const mli_tensor *slope_coeff,
+        mli_tensor *out);
+
+static MLI_FORCE_INLINE mli_status leaky_relu_sa8_run(const mli_tensor *in, 
+        const mli_tensor *slope_coeff,
+        mli_tensor *out);
+
+} // namespace ref
+
+////////////////////////////////////////////////////////////////////////////////
+// DSP
+////////////////////////////////////////////////////////////////////////////////
+namespace dsp {
+
+template <typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift);
+
+template <typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift,
+        const int remaining_part);
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params);
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int remaining_part);
+
+} // namespace dsp
+
+////////////////////////////////////////////////////////////////////////////////
+// VDSP
+////////////////////////////////////////////////////////////////////////////////
+namespace vdsp {
+
+template<typename io_T>
+MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift);
+
+template<typename io_T>
+MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(io_T) vec_in,
+        MLI_OUT_PTR(io_T) vec_out,
+        const io_T scale,
+        const int shift,
+        const int remaining_part);
+
+template<typename io_T>
+static MLI_FORCE_INLINE void compute_leaky_relu_fx_inner_loop(
+        const MLI_PTR(io_T) __restrict vec_in,
+        MLI_OUT_PTR(io_T) __restrict vec_out,
+        const io_T scale,
+        const int shift,
+        const int count,
+        const int remaining_part);
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params);
+
+static MLI_FORCE_INLINE void compute_leaky_relu(
+        const MLI_PTR(int8_t) vec_in,
+        MLI_OUT_PTR(int8_t) vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int remaining_part);
+
+static MLI_FORCE_INLINE void compute_leaky_relu_sa8_inner_loop(
+        const MLI_PTR(int8_t) __restrict vec_in,
+        MLI_OUT_PTR(int8_t) __restrict vec_out,
+        const int16_t in_zp,
+        const s8asym_quant_params *identity_params,
+        const s8asym_quant_params *alpha_params,
+        const int count,
+        const int remaining_part);
+
+} // namespace vdsp
+
+} // namespace krn
+} // namespace mli
+
+#endif // _MLI_KRN_LEAKY_RELU_DECL_H_

--- a/lib/src/kernels/transform/mli_krn_leaky_relu_fx.cc
+++ b/lib/src/kernels/transform/mli_krn_leaky_relu_fx.cc
@@ -14,7 +14,7 @@
 #include "mli_prv_dsp.h"
 #include "mli_prv_load_store.h"
 #include "mli_prv_tensor.h"
-#include "mli_krn_prelu.h"
+#include "mli_krn_leaky_relu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,8 +27,7 @@ mli_status mli_krn_leaky_relu_fx8(const mli_tensor *in, const mli_tensor *slope_
     if (ret != MLI_STATUS_OK) return ret;
     MLI_PRINT_COMPILE_OPTIONS();
 
-    const mli_prelu_cfg cfg = {/*axis*/ -1};
-    return mli::krn::prelu_fx_run<int8_t>(in, slope_coeff, &cfg, out);
+    return mli::krn::leaky_relu_fx_run<int8_t>(in, slope_coeff, out);
 }
 
 mli_status mli_krn_leaky_relu_fx16(const mli_tensor *in, const mli_tensor *slope_coeff, mli_tensor *out) {
@@ -36,8 +35,7 @@ mli_status mli_krn_leaky_relu_fx16(const mli_tensor *in, const mli_tensor *slope
     if (ret != MLI_STATUS_OK) return ret;
     MLI_PRINT_COMPILE_OPTIONS();
 
-    const mli_prelu_cfg cfg = {/*axis*/ -1};
-    return mli::krn::prelu_fx_run<int16_t>(in, slope_coeff, &cfg, out);
+    return mli::krn::leaky_relu_fx_run<int16_t>(in, slope_coeff, out);
 }
 
 mli_status mli_krn_leaky_relu_sa8(const mli_tensor *in, const mli_tensor *slope_coeff, mli_tensor *out) {
@@ -45,8 +43,7 @@ mli_status mli_krn_leaky_relu_sa8(const mli_tensor *in, const mli_tensor *slope_
     if (ret != MLI_STATUS_OK) return ret;
     MLI_PRINT_COMPILE_OPTIONS();
 
-    const mli_prelu_cfg cfg = {/*axis*/ -1};
-    return mli::krn::prelu_sa8_run(in, slope_coeff, &cfg, out);
+    return mli::krn::leaky_relu_sa8_run(in, slope_coeff, out);
 }
 #pragma MLI_CODE_SECTION_END()
 

--- a/lib/src/kernels/transform/mli_krn_prelu.cc
+++ b/lib/src/kernels/transform/mli_krn_prelu.cc
@@ -10,6 +10,7 @@
 #include "mli_check.h"
 #include "mli_debug.h"
 #include "mli_krn_prelu.h"
+#include "mli_api.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,8 +25,12 @@ mli_status mli_krn_prelu_fx8(const mli_tensor *in,
     mli_status ret = MLI_CHECK_STATUS(mli_chk_prelu_fx8(in, slope_coeff, cfg, out), __func__);
     if (ret != MLI_STATUS_OK) return ret;
     MLI_PRINT_COMPILE_OPTIONS();
-
-    return mli::krn::prelu_fx_run<int8_t>(in, slope_coeff, cfg, out);
+    
+    if (cfg->axis == -1) {
+        return mli_krn_leaky_relu_fx8(in, slope_coeff, out);
+    } else {
+        return mli::krn::prelu_fx_run<int8_t>(in, slope_coeff, cfg, out);
+    }
 }
 
 mli_status mli_krn_prelu_fx16(const mli_tensor *in,
@@ -36,7 +41,11 @@ mli_status mli_krn_prelu_fx16(const mli_tensor *in,
     if (ret != MLI_STATUS_OK) return ret;
     MLI_PRINT_COMPILE_OPTIONS();
 
-    return mli::krn::prelu_fx_run<int16_t>(in, slope_coeff, cfg, out);
+    if (cfg->axis == -1) {
+        return mli_krn_leaky_relu_fx16(in, slope_coeff, out);
+    } else {
+        return mli::krn::prelu_fx_run<int16_t>(in, slope_coeff, cfg, out);
+    }
 }
 
 mli_status mli_krn_prelu_sa8(const mli_tensor *in,
@@ -47,7 +56,11 @@ mli_status mli_krn_prelu_sa8(const mli_tensor *in,
     if (ret != MLI_STATUS_OK) return ret;
     MLI_PRINT_COMPILE_OPTIONS();
 
-    return mli::krn::prelu_sa8_run(in, slope_coeff, cfg, out);
+    if (cfg->axis == -1) {
+        return mli_krn_leaky_relu_sa8(in, slope_coeff, out);
+    } else {
+        return mli::krn::prelu_sa8_run(in, slope_coeff, cfg, out);
+    }
 }
 #pragma MLI_CODE_SECTION_END()
 

--- a/lib/src/kernels/transform/mli_krn_relu_decl.h
+++ b/lib/src/kernels/transform/mli_krn_relu_decl.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2020, Synopsys, Inc.
+* Copyright 2020-2021, Synopsys, Inc.
 * All rights reserved.
 *
 * This source code is licensed under the BSD-3-Clause license found in
@@ -28,6 +28,14 @@ namespace krn {
 ////////////////////////////////////////////////////////////////////////////////
 namespace ref {
 
+template<typename io_T>
+static MLI_FORCE_INLINE void compute_relu_inner_loop(
+        const MLI_PTR(io_T) __restrict vec_in,
+        MLI_OUT_PTR(io_T) __restrict vec_out,
+        const io_T min_val,
+        const io_T max_val,
+        const int count);
+
 template <typename io_T, bool asym>
 static MLI_FORCE_INLINE mli_status mli_krn_relu_fx_run(const mli_tensor *in, 
         const mli_relu_cfg *cfg, mli_tensor *out); 
@@ -45,6 +53,14 @@ namespace dsp {
 // VDSP
 ////////////////////////////////////////////////////////////////////////////////
 namespace vdsp {
+
+template<typename io_T>
+static MLI_FORCE_INLINE void compute_relu_inner_loop(
+        const MLI_PTR(io_T) __restrict vec_in,
+        MLI_OUT_PTR(io_T) __restrict vec_out,
+        const io_T min_val,
+        const io_T max_val,
+        const int count);
 
 } // namespace vdsp
 

--- a/lib/src/private/mli_prv_tensor.h
+++ b/lib/src/private/mli_prv_tensor.h
@@ -450,8 +450,8 @@ static MLI_FORCE_INLINE void mli_prv_squash_generic_tensor(
 }
 
 static MLI_FORCE_INLINE int mli_prv_squash_tensor_to_one_dim(
-                   const mli_tensor *in,
-                    mli_tensor *out) {
+        const mli_tensor *in,
+        mli_tensor *out) {
 
     int rank = in->rank;
     int shape = in->shape[rank - 1];
@@ -470,9 +470,9 @@ static MLI_FORCE_INLINE int mli_prv_squash_tensor_to_one_dim(
 }
 
 static MLI_FORCE_INLINE int mli_prv_squash_tensor_to_one_dim(
-                   const mli_tensor *in1,
-                   const mli_tensor *in2,
-                    mli_tensor *out) {
+        const mli_tensor *in1,
+        const mli_tensor *in2,
+        mli_tensor *out) {
 
     int rank = in1->rank;
     int shape = in1->shape[rank - 1];
@@ -1008,10 +1008,10 @@ mli_prv_get_relu_limits (const mli_relu_cfg * cfg, const mli_tensor * out) {
 
 static MLI_FORCE_INLINE bool mli_prv_is_inside_vccm (const void *ptr) {
 #if core_config_vec_mem_size
-	return ((uint32_t)ptr >= core_config_vec_mem_base) &&
-		   ((uint32_t)ptr < core_config_vec_mem_base + core_config_vec_mem_size);
+    return ((uint32_t)ptr >= core_config_vec_mem_base) &&
+           ((uint32_t)ptr < core_config_vec_mem_base + core_config_vec_mem_size);
 #else
-	return false;
+    return false;
 #endif
 }
 #endif //_MLI_PRV_TENSOR_H_


### PR DESCRIPTION
  - Using mul_hi in case shift > 15.
  - Using unroll with factor 4.
  - Using Squash to one dim.
  - Split LeakyRelu and PRELU Code to two separate components.

RID: 1186517