### PR TITLE
[more strict warning setting for MSVC]

### DIFF
--- a/lib/mli_lib.cmake
+++ b/lib/mli_lib.cmake
@@ -92,10 +92,15 @@ if (ARC)
         -Wno-nonportable-include-path
     )
 elseif (MSVC)
-    list(APPEND MLI_LIB_PRIVATE_COMPILE_OPTIONS
-        /W2
-        /WX
-    )
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        list(APPEND MLI_LIB_PRIVATE_COMPILE_OPTIONS
+            /W3
+            /WX
+        )
+    else()
+        # This path happens when other MSVC-commandline compatible
+        # compilers are used like CLANG in Visual Studio.
+    endif()
 else()
     list(APPEND MLI_LIB_PRIVATE_COMPILE_OPTIONS
         -Werror

--- a/lib/src/helpers/src/impl/mli_hlp_convert_tensor_ref.h
+++ b/lib/src/helpers/src/impl/mli_hlp_convert_tensor_ref.h
@@ -88,7 +88,7 @@ mli_status convert_quantized_data(const mli_tensor * src, mli_tensor * dst) {
                         MLI_ASSERT(dst_pos < dst_tensor_size);
                         acc_T dst_acc = mli_math_mul_fx<mul_T, acc_T>(src_tensor_arr[src_pos], scale);
                         out_T dst_val = mli_math_cast_fx<acc_T, out_T>(dst_acc, scale_shift);
-                        dst_tensor_arr[dst_pos] = mli_math_add_fx<out_T>(dst_val, zero_point);
+                        dst_tensor_arr[dst_pos] = mli_math_add_fx<out_T>(dst_val, (out_T)zero_point);
                     }
                 }
             }

--- a/lib/src/kernels/diverse/impl/mli_krn_permute_ref.h
+++ b/lib/src/kernels/diverse/impl/mli_krn_permute_ref.h
@@ -37,10 +37,10 @@ static void mli_krn_permute_calc(const mli_tensor *in, uint32_t *out_shape, int 
         out_increments[dim_ctr] -= out_increments[dim_ctr + 1] * out_shape[dim_ctr + 1];
     }
 
-    for (int d0_cnt = 0; d0_cnt < out_shape[0]; d0_cnt++) {
-        for (int d1_cnt = 0; d1_cnt < out_shape[1]; d1_cnt++) {
-            for (int d2_cnt = 0; d2_cnt < out_shape[2]; d2_cnt++) {
-                for (int d3_cnt = 0; d3_cnt < out_shape[3]; d3_cnt++) {
+    for (int d0_cnt = 0; d0_cnt < (int)out_shape[0]; d0_cnt++) {
+        for (int d1_cnt = 0; d1_cnt < (int)out_shape[1]; d1_cnt++) {
+            for (int d2_cnt = 0; d2_cnt < (int)out_shape[2]; d2_cnt++) {
+                for (int d3_cnt = 0; d3_cnt < (int)out_shape[3]; d3_cnt++) {
                     *output = input[d0_cnt * inp_stride_0 + d1_cnt * inp_stride_1 \
                             + d2_cnt * inp_stride_2 + d3_cnt * inp_stride_3];
                     output += out_increments[3];
@@ -108,21 +108,21 @@ static MLI_FORCE_INLINE mli_status mli_krn_permute_run(const mli_tensor *in, con
             if(out->el_params.sa.zero_point.mem.pi16 == nullptr) {
                 out->el_params.sa.zero_point.mem.pi16 = in->el_params.sa.zero_point.mem.pi16;
             } else if (out->el_params.sa.zero_point.mem.pi16 != in->el_params.sa.zero_point.mem.pi16) {
-                for (int dim_cnt = 0; dim_cnt < in->shape[in->el_params.sa.dim]; dim_cnt++) 
+                for (int dim_cnt = 0; dim_cnt < (int)(in->shape[in->el_params.sa.dim]); dim_cnt++) 
                     out->el_params.sa.zero_point.mem.pi16[dim_cnt] = in->el_params.sa.zero_point.mem.pi16[dim_cnt];
             }
 
             if (out->el_params.sa.scale.mem.pi16 == nullptr) {
                 out->el_params.sa.scale.mem.pi16 = in->el_params.sa.scale.mem.pi16;
             } else if (out->el_params.sa.scale.mem.pi16 != in->el_params.sa.scale.mem.pi16) {
-                for (int dim_cnt = 0; dim_cnt < in->shape[in->el_params.sa.dim]; dim_cnt++) 
+                for (int dim_cnt = 0; dim_cnt < (int)(in->shape[in->el_params.sa.dim]); dim_cnt++) 
                     out->el_params.sa.scale.mem.pi16[dim_cnt] = in->el_params.sa.scale.mem.pi16[dim_cnt];
             }
 
             if (out->el_params.sa.scale_frac_bits.mem.pi8 == nullptr) {
                 out->el_params.sa.scale_frac_bits.mem.pi8 = in->el_params.sa.scale_frac_bits.mem.pi8;
             } else if (out->el_params.sa.scale_frac_bits.mem.pi8 != in->el_params.sa.scale_frac_bits.mem.pi8) {
-                for (int dim_cnt = 0; dim_cnt < in->shape[in->el_params.sa.dim]; dim_cnt++) 
+                for (int dim_cnt = 0; dim_cnt < (int)(in->shape[in->el_params.sa.dim]); dim_cnt++) 
                     out->el_params.sa.scale_frac_bits.mem.pi8[dim_cnt] = in->el_params.sa.scale_frac_bits.mem.pi8[dim_cnt];
             }
         }

--- a/lib/src/kernels/eltwise/impl/mli_krn_eltwise_ref.h
+++ b/lib/src/kernels/eltwise/impl/mli_krn_eltwise_ref.h
@@ -81,7 +81,7 @@ out_T eltwise_perform_operation(
         break;
 
     case ELTWISE_MUL:
-        acc = mli_math_mul_fx<int32_t, int64_t> (input1, input2);
+        acc = (accu_T)(mli_math_mul_fx<int32_t, int64_t> (input1, input2));
         break;
 
     case ELTWISE_MAX:
@@ -128,7 +128,7 @@ MLI_FORCE_INLINE int8_t eltwise_perform_operation<int8_t, int8_t, ELTWISE_MUL, t
     input1 = mli_math_sub_fx<int16_t> (op1, in_offset1);
     input2 = mli_math_sub_fx<int16_t> (op2, in_offset2);
 
-    acc = mli_math_mul_fx<int32_t, int64_t> (input1, input2);
+    acc = (int32_t)mli_math_mul_fx<int32_t, int64_t> (input1, input2);
     const int headroom = 3;
     const int acc_len = 32;
     const int out_len = 8;

--- a/lib/src/kernels/pooling/mli_krn_pool_hwc.h
+++ b/lib/src/kernels/pooling/mli_krn_pool_hwc.h
@@ -318,7 +318,7 @@ static MLI_FORCE_INLINE void mli_krn_pool_hwc_pad(
                     area.clmn_beg = 0;
                     area.clmn_end = out.width - CEIL_DIV(padding_right, stride_width);
                     // compensate for cases where kernel size is larger than input size
-                    area.clmn_end = MAX(CEIL_DIV(padding_left, stride_width), area.clmn_end);
+                    area.clmn_end = MAX(CEIL_DIV(padding_left, stride_width), (int)area.clmn_end);
                 } else {
                     continue;
                 }

--- a/lib/src/move/impl/mli_mov_ref.h
+++ b/lib/src/move/impl/mli_mov_ref.h
@@ -47,10 +47,10 @@ static MLI_FORCE_INLINE void mov_inner_loop (mli_mov_handle_t* h, const io_T* __
             dst[inner_dst_pos] = 0;
         }
     } else {
-        for (int inner_idx = 0; inner_idx < inner_dst_size; inner_idx++) {
+        for (int inner_idx = 0; inner_idx < (int)(inner_dst_size); inner_idx++) {
             int inner_src_pos = inner_idx * inner_subsample + inner_src_offset - inner_pre_padding;
             int inner_dst_pos = (inner_idx + inner_dst_offset) * inner_dst_strde;
-            if (inner_src_pos < 0 || inner_src_pos >= inner_src_shape ) {
+            if (inner_src_pos < 0 || inner_src_pos >= (int)inner_src_shape ) {
                 dst[inner_dst_pos] = 0;
             } else {
                 dst[inner_dst_pos] = src[inner_src_pos * inner_src_strde];
@@ -69,7 +69,7 @@ static MLI_FORCE_INLINE void mov_inner_loop (mli_mov_handle_t* h, const io_T* __
         bool src_in_vccm, bool dst_in_vccm,
         bool no_inner_src_stride, bool no_inner_dst_stride, bool small_size) {
         uint32_t inner_src_step = inner_subsample * inner_src_strde;
-        for (int inner_idx = 0; inner_idx < inner_dst_size; inner_idx++) {
+        for (int inner_idx = 0; inner_idx < (int)(inner_dst_size); inner_idx++) {
             int inner_src_pos = inner_idx * inner_src_step;
             int inner_dst_pos = inner_idx * inner_dst_strde;
             dst[inner_dst_pos] = src[inner_src_pos];
@@ -85,9 +85,9 @@ static MLI_FORCE_INLINE void mli_mov_basic_operation (mli_mov_handle_t* h, const
     uint8_t* ordered_post_padding, uint8_t* ordered_pdim, uint32_t* ordered_offset, uint32_t* ordered_dst_offset,
     uint32_t* ordered_subsample, bool no_padding, bool src_in_vccm, bool dst_in_vccm ) {
     if (no_padding) {
-        for (int pos0 = 0; pos0 < ordered_dst_write_size[0]; pos0++) {
-            for (int pos1 = 0; pos1 < ordered_dst_write_size[1]; pos1++) {
-                for (int pos2 = 0; pos2 < ordered_dst_write_size[2]; pos2++) {
+        for (int pos0 = 0; pos0 < (int)(ordered_dst_write_size[0]); pos0++) {
+            for (int pos1 = 0; pos1 < (int)(ordered_dst_write_size[1]); pos1++) {
+                for (int pos2 = 0; pos2 < (int)(ordered_dst_write_size[2]); pos2++) {
 
                     int dst_pos = (pos0 + ordered_dst_offset[0]) * ordered_dst_mem_stride[0]
                                 + (pos1 + ordered_dst_offset[1]) * ordered_dst_mem_stride[1]
@@ -115,9 +115,9 @@ static MLI_FORCE_INLINE void mli_mov_basic_operation (mli_mov_handle_t* h, const
             }
         }
     } else {
-        for (int pos0 = 0; pos0 < ordered_dst_write_size[0]; pos0++) {
-            for (int pos1 = 0; pos1 < ordered_dst_write_size[1]; pos1++) {
-                for (int pos2 = 0; pos2 < ordered_dst_write_size[2]; pos2++) {
+        for (int pos0 = 0; pos0 < (int)(ordered_dst_write_size[0]); pos0++) {
+            for (int pos1 = 0; pos1 < (int)(ordered_dst_write_size[1]); pos1++) {
+                for (int pos2 = 0; pos2 < (int)(ordered_dst_write_size[2]); pos2++) {
                       int dst_pos = (pos0 + ordered_dst_offset[0]) * ordered_dst_mem_stride[0]
                                   + (pos1 + ordered_dst_offset[1]) * ordered_dst_mem_stride[1]
                                   + (pos2 + ordered_dst_offset[2]) * ordered_dst_mem_stride[2];
@@ -127,9 +127,9 @@ static MLI_FORCE_INLINE void mli_mov_basic_operation (mli_mov_handle_t* h, const
                       int src_pos2 = pos2 * ordered_subsample[ordered_pdim[2]] + ordered_offset[ordered_pdim[2]] - ordered_pre_padding[ordered_pdim[2]];
 
 
-                      bool in_padding_area = (((src_pos0 < 0) || (src_pos0  >= ordered_src_shape[ordered_pdim[0]])))
-                                          || (((src_pos1 < 0) || (src_pos1  >= ordered_src_shape[ordered_pdim[1]])))
-                                          || (((src_pos2 < 0) || (src_pos2  >= ordered_src_shape[ordered_pdim[2]])));
+                      bool in_padding_area = (((src_pos0 < 0) || (src_pos0  >= (int)(ordered_src_shape[ordered_pdim[0]]))))
+                                          || (((src_pos1 < 0) || (src_pos1  >= (int)(ordered_src_shape[ordered_pdim[1]]))))
+                                          || (((src_pos2 < 0) || (src_pos2  >= (int)(ordered_src_shape[ordered_pdim[2]]))));
 
                       int src_pos = src_pos0 * ordered_src_mem_stride[ordered_pdim[0]]
                                   + src_pos1 * ordered_src_mem_stride[ordered_pdim[1]]

--- a/lib/src/private/mli_prv_tensor.h
+++ b/lib/src/private/mli_prv_tensor.h
@@ -238,7 +238,7 @@ MLI_FORCE_INLINE void mli_prv_tensor_inc_data_ptr<int8_t*>
     int element_size = sizeof(int8_t);
     MLI_ASSERT((tensor->el_type == MLI_EL_FX_8) ||
                (tensor->el_type == MLI_EL_SA_8));
-    MLI_ASSERT(element_size * elements <= tensor->data.capacity);
+    MLI_ASSERT(element_size * elements <= (int)(tensor->data.capacity));
     tensor->data.mem.pi8 += elements;
     tensor->data.capacity -= elements * element_size;
 }
@@ -249,7 +249,7 @@ MLI_FORCE_INLINE void mli_prv_tensor_inc_data_ptr<int16_t*>
 {
     int element_size = sizeof(int16_t);
     MLI_ASSERT(tensor->el_type == MLI_EL_FX_16);
-    MLI_ASSERT(element_size * elements <= tensor->data.capacity);
+    MLI_ASSERT(element_size * elements <= (int)(tensor->data.capacity));
     tensor->data.mem.pi16 += elements;
     tensor->data.capacity -= elements * element_size;
 }
@@ -260,7 +260,7 @@ MLI_FORCE_INLINE void mli_prv_tensor_inc_data_ptr<int32_t*>
 {
     int element_size = sizeof(int32_t);
     MLI_ASSERT(tensor->el_type == MLI_EL_SA_32);
-    MLI_ASSERT(element_size * elements <= tensor->data.capacity);
+    MLI_ASSERT(element_size * elements <= (int)(tensor->data.capacity));
     tensor->data.mem.pi32 += elements;
     tensor->data.capacity -= elements * element_size;
 }

--- a/make/rules.mk
+++ b/make/rules.mk
@@ -18,7 +18,7 @@ MLI_BUILD_REFERENCE ?= OFF
 BUILD_SUBDIR        ?=
 BUILD_TARGET        ?= install
 EXT_CFLAGS          ?=
-TOOLCHAIN_OPTIONS   ?=
+CMAKE_OPTIONS       ?=
 # User need to define BUILD_LIB (target specific libs including runtime)
 # if default one doesn't fit.
 BUILDLIB_DIR        ?=
@@ -27,6 +27,7 @@ VERBOSE             ?= OFF
 
 include $(PUBLIC_DIR)/make/settings.mk
 
+TOOLCHAIN_OPTIONS = $(CMAKE_OPTIONS)
 ifdef TCF_FILE
 # For TCF_FILE, we only take the realpath if the file exists (otherwise it is a file inside MWDT)
 TOOLCHAIN_OPTIONS += \


### PR DESCRIPTION
[Changes]
- if on Windows, the default toolchain is Visual Studio,
  and if multiple toolsets are installed, the following
  can be done:
gmake ROUND_MODE=UP CMAKE_OPTIONS="-T ClangCL"
gmake ROUND_MODE=UP CMAKE_OPTIONS="-T v141"
gmake ROUND_MODE=UP CMAKE_OPTIONS="-T v142"