### PR TITLE
[Docs] Dilation factor, Sphynx version, and minor fixes

### DIFF
--- a/doc/documents/mli_kernels/conv_2d.rst
+++ b/doc/documents/mli_kernels/conv_2d.rst
@@ -175,6 +175,8 @@ Ensure that you satisfy the following conditions before calling the function:
  - ``padding_left`` and ``padding_right`` parameters must be in the range of [0, weights (W)idth).
  
  - ``stride_width`` and ``stride_height`` parameters must not be equal to 0.
+
+ - ``dilation_width`` and ``dilation_height`` parameters must not be equal to 0.
  
  - Width (W) and Height (H) dimensions of the ``weights`` tensor must be less than or equal to 
    the appropriate dimensions of the ``in`` tensor. 

--- a/doc/documents/mli_kernels/conv_depthwise.rst
+++ b/doc/documents/mli_kernels/conv_depthwise.rst
@@ -167,6 +167,8 @@ Ensure that you satisfy the following conditions before calling the function:
  - ``padding_left`` and ``padding_right`` parameters must be in range of [0, weights (W)idth).
  
  - ``stride_width`` and ``stride_height`` parameters must not be equal to 0.
+
+ - ``dilation_width`` and ``dilation_height`` parameters must not be equal to 0.
  
  - Width (W) and Height (H) dimensions of the ``weights`` tensor must be less than or equal to 
    the appropriate dimensions of the ``in`` tensor.

--- a/doc/documents/mli_kernels/conv_grp.rst
+++ b/doc/documents/mli_kernels/conv_grp.rst
@@ -70,8 +70,8 @@ is derived from input and weights tensors shape. For example, in a HWCN data
 layout, if the ``in`` feature map is :math:`(Hi, Wi, Ci)` and the ``weights`` 
 tensor is :math:`(Hk, Wk, Cw, Co)`, number of groups is :math:`M = Ci / Cw`, and 
 number of filters per each group is :math:`Co / M`. 
-Therefore, number of input channels :math:`Ci` must be a multiple of :math:`Cig`, and number of 
-output channels must be multiple of number of groups. 
+Therefore, number of input channels :math:`Ci` must be a multiple of :math:`Cw`, and number of 
+output channels :math:`Co` must be a multiple of number of groups :math:`M`. 
 
 Here is a list of all available Group Convolution functions:
 
@@ -164,6 +164,8 @@ Ensure that you satisfy the following conditions before calling the function:
  - ``padding_left`` and ``padding_right`` parameters must be in range of [0, weights (W)idth).
  
  - ``stride_width`` and ``stride_height`` parameters must not be equal to 0.
+
+ - ``dilation_width`` and ``dilation_height`` parameters must not be equal to 0.
  
  - Width (W) and Height (H) dimensions of ``weights`` tensor must be less than or equal to 
    the appropriate dimensions of the ``in`` tensor.

--- a/doc/documents/mli_kernels/convolution_grp.rst
+++ b/doc/documents/mli_kernels/convolution_grp.rst
@@ -41,13 +41,13 @@ Functions in this group use the ``mli_conv2d_cfg`` structure, defined as:
    +-----------------------+---------------------+---------------------------------------------------+
    | ``dilation_width``    | ``uint8_t``         | If set to k>1, there are k-1 implicitly added     |
    |                       |                     | zero points between each filter point across      |
-   |                       |                     | width dimension. If set to 0 or 1, no dilation    |
-   |                       |                     | logic is used.                                    |
+   |                       |                     | width dimension. If set to 1, no dilation         |
+   |                       |                     | logic is used. Zero dilation is forbidden.        |
    +-----------------------+---------------------+---------------------------------------------------+
    | ``dilation_height``   | ``uint8_t``         | If set to k>1, there are k-1 implicitly added     |
    |                       |                     | zero points between each filter point across      |
-   |                       |                     | height dimension. If set to 0 or 1, no dilation   |
-   |                       |                     | logic is used.                                    |
+   |                       |                     | height dimension. If set to 1, no dilation        |
+   |                       |                     | logic is used. Zero dilation is forbidden.        |
    +-----------------------+---------------------+---------------------------------------------------+   
    | ``padding_left``      | ``uint8_t``         | Number of zero points implicitly added to the     |
    |                       |                     | left of input (width dimension)                   |

--- a/doc/documents/mli_kernels/trans_l2_norm.rst
+++ b/doc/documents/mli_kernels/trans_l2_norm.rst
@@ -43,7 +43,7 @@ Kernels which implement L2 normalization functions have the following prototype:
 
 .. code:: c
 
-   mli_status mli_krn_L2_normalize_<data_format>(
+   mli_status mli_krn_l2_normalize_<data_format>(
       const mli_tensor *in,
       const mli_tensor *epsilon,
       const mli_lut *lut,
@@ -86,13 +86,13 @@ See Table :ref:`t_mli_prelu_cfg_desc` for more details.
    :align: center
    :widths: auto
    
-   +--------------------------+-----------------------------------+
-   | **Function Name**        | **Details**                       |
-   +==========================+===================================+
-   | ``mli_krn_L2_norm_sa8``  | All tensors data format: **sa8**  |
-   +--------------------------+-----------------------------------+
-   | ``mli_krn_L2_norm_fx16`` | All tensors data format: **fx16** |
-   +--------------------------+-----------------------------------+
+   +-------------------------------+-----------------------------------+
+   | **Function Name**             | **Details**                       |
+   +===============================+===================================+
+   | ``mli_krn_l2_normalize_sa8``  | All tensors data format: **sa8**  |
+   +-------------------------------+-----------------------------------+
+   | ``mli_krn_l2_normalize_fx16`` | All tensors data format: **fx16** |
+   +-------------------------------+-----------------------------------+
 ..
 
 Ensure that you satisfy the following conditions before calling the function:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx>=3.2.1
+Sphinx==3.5.4
 sphinx-rtd-theme==0.5.0


### PR DESCRIPTION
     - Zero dilation is forbidden
     - Typo fixes (group_conv; L2Norm)
     - Sphynx Version is fixed to 3.5.4 due to bullets absence in recently released 4+

RID: #1239961
MLI_lib_test_nsim/2238:PASSED