### PR TITLE
[Docs] Minor fixes in doc and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ There are test and several examples supplied with embARC MLI Library. For inform
 These are basic API level test applications to check that all the functions available at the API level work fine.
 
 ### [**Hello World**](/examples/hello_world)
-This example is a first step API functions and data usage.
+This example is a first step into API functions and data usage.
 
 ### [**CIFAR-10**](/examples/example_cifar10_caffe)
 This example is a simple image classifier built on convolution, pooling and dense layers. It is based on standard Caffe tutorial for CIFAR-10 dataset.

--- a/doc/documents/mli_kernels/conv_2d.rst
+++ b/doc/documents/mli_kernels/conv_2d.rst
@@ -253,7 +253,7 @@ the following quantization conditions before calling the function:
    ..
 ..
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/conv_depthwise.rst
+++ b/doc/documents/mli_kernels/conv_depthwise.rst
@@ -219,7 +219,7 @@ satisfy the following quantization conditions before calling the function:
    broadcasted on weights array of scale factors. See the example for the similar condition 
    in the :ref:`conv_2d`.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/conv_grp.rst
+++ b/doc/documents/mli_kernels/conv_grp.rst
@@ -224,7 +224,7 @@ satisfy the following quantization conditions before calling the function:
    broadcasted on weights array of scale factors.  See the example for the similar condition 
    in the :ref:`conv_2d`.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/conv_transp.rst
+++ b/doc/documents/mli_kernels/conv_transp.rst
@@ -237,7 +237,7 @@ satisfy the following quantization conditions before calling the function:
  - Scale factors of bias tensor must be equal to the multiplication of input scale factor broadcasted 
    on weights array of scale factors. See the example for the similar condition in the :ref:`conv_2d`.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/div_permute.rst
+++ b/doc/documents/mli_kernels/div_permute.rst
@@ -97,12 +97,10 @@ Ensure that you satisfy the following general conditions before calling the func
 
  - ``in`` and ``out`` tensors must not point to overlapped memory regions.
 
- - ``mem_stride`` of the innermost dimension must be equal to 1 for all the tensors.
-
  - Only first N (equal to ``rank`` of ``in`` tensor) values in permutation order array are considered 
    by kernel. All of them must be unique, non-negative and less than the ``rank`` of the ``in`` tensor.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/elemw_grp.rst
+++ b/doc/documents/mli_kernels/elemw_grp.rst
@@ -108,7 +108,7 @@ the following quantization conditions before calling the function:
 
  - Zero offset of ``in1``, ``in2`` and ``out`` tensors must be within [-128, 127] range.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/pool_avg.rst
+++ b/doc/documents/mli_kernels/pool_avg.rst
@@ -124,7 +124,7 @@ satisfy the following quantization conditions before calling the function:
 
  - zero offset of ``in`` and ``out`` tensors must be within [-128, 127] range.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/pool_max.rst
+++ b/doc/documents/mli_kernels/pool_max.rst
@@ -121,7 +121,7 @@ satisfy the following quantization conditions before calling the function:
  - ``in`` and ``out`` tensors must be quantized on the tensor level. This implies that 
    each tensor contains a single scale factor and a single zero offset.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/rec_fully_con.rst
+++ b/doc/documents/mli_kernels/rec_fully_con.rst
@@ -205,7 +205,7 @@ satisfy the following quantization conditions before calling the function:
    broadcasted on weights array of scale factors. See the example for the similar condition 
    in the :ref:`conv_2d`.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/rec_gru.rst
+++ b/doc/documents/mli_kernels/rec_gru.rst
@@ -258,7 +258,7 @@ satisfy the following quantization conditions before calling the function:
    broadcasted on ``weights_in`` array of scale factors. See the example for the similar condition 
    in the :ref:`conv_2d`.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/rec_lstm.rst
+++ b/doc/documents/mli_kernels/rec_lstm.rst
@@ -277,7 +277,7 @@ satisfy the following quantization conditions before calling the function:
    broadcasted on ``weights_in`` array of scale factors. See the example for the similar condition 
    in the :ref:`conv_2d`.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/rec_rnn_dense.rst
+++ b/doc/documents/mli_kernels/rec_rnn_dense.rst
@@ -180,7 +180,7 @@ satisfy the following quantization conditions before calling the function:
    (that is, :math:`bias.scale = inputs[0].scale * weights[0].scale`). See the example for the 
    similar condition in the :ref:`conv_2d`.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/trans_l2_norm.rst
+++ b/doc/documents/mli_kernels/trans_l2_norm.rst
@@ -125,7 +125,7 @@ the following quantization conditions before calling the function:
 
  - Zero offset of ``in`` tensor must be within [-128, 127] range.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/trans_leaky_relu.rst
+++ b/doc/documents/mli_kernels/trans_leaky_relu.rst
@@ -103,7 +103,7 @@ the following quantization conditions before calling the function:
 
  - Zero offset of ``slope_coeffs`` tensor must be within [-16384, 16383] range.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/trans_param_relu.rst
+++ b/doc/documents/mli_kernels/trans_param_relu.rst
@@ -144,7 +144,7 @@ the following quantization conditions before calling the function:
 
  - Zero offset of ``slope_coeffs`` tensor must be within [-16384, 16383] range.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/trans_relu.rst
+++ b/doc/documents/mli_kernels/trans_relu.rst
@@ -118,7 +118,7 @@ the following quantization conditions before calling the function:
 
  - Zero offset of ``in`` tensor must be within [-128, 127] range.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/trans_sigmoid.rst
+++ b/doc/documents/mli_kernels/trans_sigmoid.rst
@@ -94,7 +94,7 @@ the following quantization conditions before calling the function:
  - Zero offset of ``in`` tensor must be within [-128, 127] range.
    
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/trans_softmax.rst
+++ b/doc/documents/mli_kernels/trans_softmax.rst
@@ -114,7 +114,7 @@ the following quantization conditions before calling the function:
 
  - Zero offset of ``in`` tensor must be within [-128, 127] range.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/mli_kernels/trans_tanh.rst
+++ b/doc/documents/mli_kernels/trans_tanh.rst
@@ -93,7 +93,7 @@ the following quantization conditions before calling the function:
 
  - Zero offset of ``in`` tensor must be within [-128, 127] range.
 
-Ensure that you satisfy the platform-specific conditions in addition to to those listed above 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
 (see the :ref:`platform_spec_chptr` chapter).
 
 Result

--- a/doc/documents/utility_functions/util_data_conv.rst
+++ b/doc/documents/utility_functions/util_data_conv.rst
@@ -104,6 +104,9 @@ the following quantization conditions before calling the function:
  - if ``in`` and ``out`` tensors are both quantized on per-axis level, 
    then they must share the same quantization axis (``in.el_params.sa.dim`` = ``out.el_params.sa.dim``).
 
+Ensure that you satisfy the platform-specific conditions in addition to those listed above 
+(see the :ref:`platform_spec_chptr` chapter).
+
 Result
 ^^^^^^
 

--- a/examples/example_cifar10_caffe/README.md
+++ b/examples/example_cifar10_caffe/README.md
@@ -2,6 +2,8 @@ CIFAR-10 Convolution Neural Network Example
 ==============================================
 Example is based on standard [Caffe tutorial](http://caffe.berkeleyvision.org/gathered/examples/cifar10.html) for [CIFAR-10](http://www.cs.toronto.edu/~kriz/cifar.html) dataset. It's a simple classifier built on convolution, pooling and dense layers for tiny images.
 
+**Important note:** Example doesn't work for VPX configurations without guard bits as it produces incorrect results due to accumulator overflow during calculations.
+
 # Building and Running
 
 You need to configure and build the library project for the desired platform. 

--- a/examples/example_face_detect/README.md
+++ b/examples/example_face_detect/README.md
@@ -7,6 +7,8 @@ It shows how advanced but still compact models might be implemented utilizing li
 Slicing logic helps to split calculation of large intermediate feature maps into parts 
 propagating it through the network architecture towards layers with more compact output. 
 
+**Important note:** Example doesn’t work for VPX configurations without guard bits as it produces incorrect results due to accumulator overflow during calculations.
+
 # Building and Running
 
 You need to configure and build the library project for the desired platform. 

--- a/examples/example_har_smartphone/README.md
+++ b/examples/example_har_smartphone/README.md
@@ -9,6 +9,8 @@ Example shows how to work with recurrent primitives (LSTM and basic RNN) impleme
  * 4: STANDING
  * 5: LAYING
 
+**Important note:** Example doesn’t work for VPX configurations without guard bits as it produces incorrect results due to accumulator overflow during calculations.
+
 # Building and Running
 
 You need to configure and build the library project for the desired platform. 

--- a/examples/tutorial_emnist_tflm/README.md
+++ b/examples/tutorial_emnist_tflm/README.md
@@ -2,7 +2,9 @@ EMNIST Conversion Example
 ========================================================================
 This example shows how to convert EMNIST Tensorflow model into Tensorflow Lite Micro format and use it in embARC MLI application.
 
-**Important note:** this example won't work with EM/HS platform. For EM/HS, please use [MLI 1.1 release version](https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_mli/tree/Release_1.1/examples/tutorial_emnist_tflm).
+ **Important notes:**
+ * Example doesn’t work for VPX configurations without guard bits as it produces incorrect results due to accumulator overflow during calculations.
+ * Example won't work with EM/HS platform. For EM/HS, please use [MLI 1.1 release version](https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_mli/tree/Release_1.1/examples/tutorial_emnist_tflm).
 
 ## Requirements
 ---------------


### PR DESCRIPTION
 - Relax restriction on memstrides for permute
 - fix double "to" in statements for all kernels (and add the statement for conversion)
 - Claim that examples doesn't support configurations without guardbits


RID:1264094
ML_lib_test_nsim/2475:PASS