### PR TITLE
Mli 1 1 patch

### DIFF
--- a/build/rules.mk
+++ b/build/rules.mk
@@ -140,7 +140,7 @@ ifeq ($(TOOLCHAIN),mwdt)
  AR = arac
  AS = ccac
  TCF_CFLAGS += -tcf=$(TCF_FILE) -tcf_core_config
- LDFLAGS += -tcf=$(TCF_FILE) $(LCF)
+ LDFLAGS += $(LCF)
 else 
  CC = arc-elf32-gcc
  LD = arc-elf32-ld

--- a/build/rules.mk
+++ b/build/rules.mk
@@ -118,7 +118,6 @@ DEPFLAGS    =
 else
 ifeq ($(TOOLCHAIN),mwdt)
 # place to add MWDT-specific common settings
-CFLAGS     +=-Hon=Long_enums
 CFLAGS     +=-mllvm -gen-lpcc=false
 DEPFLAGS    =-Hdepend=$(BUILD_DIR)/ -MD
 else


### PR DESCRIPTION
Starting with MWDT 2023.06 the new LLVM based lldac is used as the default linker instead of the old MetaWare ldac linker. This new lldac linker does not accept the -tcf option that is passed directly to the linker using the -Wl,-tcf\=../../hw/em9d.tcf ccac driver option. Passing the -tcf option directly to the linker is redundant